### PR TITLE
ARGO-931 Alerta-mailer rule generator from gocdb contact data

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Overview
 --------
 
 Publisher of argo-streaming status events as alerts to an alerta service endpoint.
+Alerta mail configuration rules from gocdb contact data.
 
 Argo streaming-service produces status events with the following schema:
 ```
@@ -28,6 +29,16 @@ There are four types of status events: `[ "endpoint_group", "service", "endpoint
 Argo-alert connects to a kafka-topic and receives such status events. Each event is
 then transformed to a compatible alerta schema and gets published to an alerta service endpoint.
 
+Alerta-mailer rule generation
+---------------------------
+Argo-alert provides the ability to create alerta-mailer rules from gocdb contact data. Argo-alert
+connects to a defined gocdb api endpoint and transforms the xml contact information to alerta-mailer
+rule json format. The rules are saved to a defined output file. 
+
+The configuration file for argo-alert provides a `[gocdb]` section to configure the gocdb endpoint
+and the required certificate parameters for access. The `mail-rules` parameter in `[alerta]` section 
+specifies the alerta-mailer rule filename for output.  
+
 
 Installation / Usage
 --------------------
@@ -45,6 +56,13 @@ Or clone the repo:
 
 argoalert requires a configuration file with the following options:
 ```
+[gocdb]
+api=https://goc.egi.eu/gocdbpi/public/?method=get_site
+cabundle=/home/kaggis/Desktop/certs/hellasgrid
+hostcert=/home/kaggis/Desktop/certs/file.crt.pem
+hostkey=/home/kaggis/Desktop/certs/file.key.pem
+verify=False
+
 [kafka]
 endpoint=localhost:9092
 topic=metrics
@@ -53,15 +71,20 @@ topic=metrics
 endpoint=http://localhost:8080
 environment=devel
 token=s3cr3tt0ke3n
+mail-rules=/home/kaggis/alerta-rules-101
 
 [logging]
 level = INFO
 
 ```
 
-To run argo-alert:
+To run argo-alert publisher:
 
-    $ argo-alert -c /path/to/argo-alert.conf
+    $ argo-alert-publisher -c /path/to/argo-alert.conf
+
+To run argo-alert mail rule generator:
+    
+    $ argo-alert-rulegen -c /path/to/argo-alert.conf
 
 Run tests
 ---------

--- a/bin/argo-alert-publisher
+++ b/bin/argo-alert-publisher
@@ -3,7 +3,8 @@
 from argparse import ArgumentParser
 from ConfigParser import SafeConfigParser
 import sys
-import argoalert
+from argoalert import argoalert
+import logging
 
 def main(args=None):
 
@@ -17,16 +18,16 @@ def main(args=None):
     environment = parser.get("alerta", "environment")
     alerta_token = parser.get("alerta", "token")
     log_level = parser.get("logging", "level")
+    logging.basicConfig(level=log_level)
 
-    start_listening(environment, log_level, kafka_endpoint, kafka_topic,
+    argoalert.start_listening(environment, kafka_endpoint, kafka_topic,
                     alerta_endpoint, alerta_token)
 
 
 if __name__ == "__main__":
-    # Feed Argument parser with the description of the 3 arguments we need
-    # (input_file,output_file,schema_file)
+
     arg_parser = ArgumentParser(
-        description="ingest argo status data to alerta system")
+        description="publish argo status events to alerta server")
     arg_parser.add_argument(
         "-c", "--config", help="config", dest="config", metavar="string",
         required="TRUE")

--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+from argparse import ArgumentParser
+from ConfigParser import SafeConfigParser
+import sys
+import logging
+from argoalert import argoalert
+
+def main(args=None):
+
+    # Init configuration
+    parser = SafeConfigParser()
+    parser.read(args.config)
+
+    gocdb_api = parser.get("gocdb", "api")
+    ca_bundle = parser.get("gocdb", "cabundle")
+    hostcert = parser.get("gocdb", "hostcert")
+    hostkey = parser.get("gocdb", "hostkey")
+    verify = parser.get("gocdb", "verify")
+
+    rule_file = parser.get("alerta", "mail-rules")
+    log_level = parser.get("logging", "level")
+    logging.basicConfig(level=log_level)
+
+    # Get data from gocdb
+    gocdb_xml = argoalert.get_gocdb(gocdb_api, ca_bundle, hostcert, hostkey,
+                                        verify)
+
+    # Convert gocdb xml data to contacts object
+    contacts = argoalert.gocdb_to_contacts(gocdb_xml)
+
+    # Convert contacts to alerta mail rules
+    rules = argoalert.contacts_to_alerta(contacts)
+
+    # Save rules to alerta mailer rule file
+    argoalert.write_rules(rules, rule_file)
+
+
+if __name__ == "__main__":
+
+    arg_parser = ArgumentParser(
+        description="create argo-alerta mail rules from gocdb contacts")
+    arg_parser.add_argument(
+        "-c", "--config", help="config", dest="config", metavar="string",
+        required="TRUE")
+
+    # Parse the command line arguments accordingly and introduce them to
+    # main...
+    sys.exit(main(arg_parser.parse_args()))

--- a/conf/argo-alert.conf
+++ b/conf/argo-alert.conf
@@ -1,3 +1,10 @@
+[gocdb]
+api=https://goc.egi.eu/gocdbpi/public/?method=get_site
+cabundle=/home/kaggis/Desktop/certs/hellasgrid
+hostcert=/home/kaggis/Desktop/certs/file.crt.pem
+hostkey=/home/kaggis/Desktop/certs/file.key.pem
+verify=False
+
 [kafka]
 endpoint=localhost:9092
 topic=metrics
@@ -6,6 +13,7 @@ topic=metrics
 endpoint=http://localhost:8080
 environment=devel
 token=s3cr3tt0ke3n
+mail-rules=/home/kaggis/alerta-rules-101
 
 [logging]
 level = INFO

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ dependency_links = [x.strip().replace('git+', '') for x in all_reqs if x.startsw
 
 setup(
     name='argoalert',
-    scripts=['bin/argo-alert'],
+    scripts=['bin/argo-alert-publisher','bin/argo-alert-rulegen'],
     version=__version__,
     description='Publisher of argo-streaming status events as alerts to an alerta service endpoint',
     long_description=long_description,

--- a/tests/files/contacts.json
+++ b/tests/files/contacts.json
@@ -1,0 +1,33 @@
+[
+    {
+      "type":"SITE",
+      "name":"Site-A",
+      "email":"admin@site-a.email.foo"
+    },
+    {
+      "type":"SITE",
+      "name":"Site-B",
+      "email":"admin@site-b.email.foo"
+    },
+    {
+      "type":"SITE",
+      "name":"Site-C",
+      "email":"admin@site-c.email.foo"
+    },
+    {
+      "type":"SITE",
+      "name":"Site-D",
+      "email":"admin@site-d.email.foo"
+    },
+    {
+      "type":"SITE",
+      "name":"Site-E",
+      "email":"admin@site-e.email.foo"
+    },
+    {
+      "type":"SITE",
+      "name":"Site-F",
+      "email":"admin@site-f.email.foo"
+    }
+]
+

--- a/tests/files/gocdb-foo.xml
+++ b/tests/files/gocdb-foo.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<results>
+  <SITE ID="0" PRIMARY_KEY="0G0" NAME="Site-A">
+    <PRIMARY_KEY>0G0</PRIMARY_KEY>
+    <SHORT_NAME>Site-A</SHORT_NAME>
+    <OFFICIAL_NAME>Site-A full name</OFFICIAL_NAME>
+    <HOME_URL>http://site-a.foo</HOME_URL>
+    <CONTACT_EMAIL>admin@site-a.email.foo</CONTACT_EMAIL>
+  </SITE>
+  <SITE ID="1" PRIMARY_KEY="0G1" NAME="Site-B">
+    <PRIMARY_KEY>0G1</PRIMARY_KEY>
+    <SHORT_NAME>Site-B</SHORT_NAME>
+    <OFFICIAL_NAME>Site-B full name</OFFICIAL_NAME>
+    <HOME_URL>http://site-b.foo</HOME_URL>
+    <CONTACT_EMAIL>admin@site-b.email.foo</CONTACT_EMAIL>
+  </SITE>
+  <SITE ID="2" PRIMARY_KEY="0G2" NAME="Site-C">
+    <PRIMARY_KEY>0G2</PRIMARY_KEY>
+    <SHORT_NAME>Site-C</SHORT_NAME>
+    <OFFICIAL_NAME>Site-C full name</OFFICIAL_NAME>
+    <HOME_URL>http://site-C.foo</HOME_URL>
+    <CONTACT_EMAIL>admin@site-c.email.foo</CONTACT_EMAIL>
+  </SITE>
+  <SITE ID="3" PRIMARY_KEY="0G3" NAME="Site-D">
+    <PRIMARY_KEY>0G3</PRIMARY_KEY>
+    <SHORT_NAME>Site-D</SHORT_NAME>
+    <OFFICIAL_NAME>Site-D full name</OFFICIAL_NAME>
+    <HOME_URL>http://site-d.foo</HOME_URL>
+    <CONTACT_EMAIL>admin@site-d.email.foo</CONTACT_EMAIL>
+  </SITE>
+  <SITE ID="4" PRIMARY_KEY="0G4" NAME="Site-E">
+    <PRIMARY_KEY>0G4</PRIMARY_KEY>
+    <SHORT_NAME>Site-E</SHORT_NAME>
+    <OFFICIAL_NAME>Site-E full name</OFFICIAL_NAME>
+    <HOME_URL>http://site-e.foo</HOME_URL>
+    <CONTACT_EMAIL>admin@site-e.email.foo</CONTACT_EMAIL>
+  </SITE>
+  <SITE ID="5" PRIMARY_KEY="0G5" NAME="Site-F">
+    <PRIMARY_KEY>0G5</PRIMARY_KEY>
+    <SHORT_NAME>Site-F</SHORT_NAME>
+    <OFFICIAL_NAME>Site-F full name</OFFICIAL_NAME>
+    <HOME_URL>http://site-f.foo</HOME_URL>
+    <CONTACT_EMAIL>admin@site-f.email.foo</CONTACT_EMAIL>
+  </SITE>
+</results>

--- a/tests/files/rules.json
+++ b/tests/files/rules.json
@@ -1,0 +1,50 @@
+[
+    {
+        "name": "rule_Site-A",
+        "fields": [
+            {"field": "resource", "regex": "Site-A"}
+        ],
+        "contacts": ["admin@site-a.email.foo"],
+        "exclude":true
+    },
+    {
+        "name": "rule_Site-B",
+        "fields": [
+            {"field": "resource", "regex": "Site-B"}
+        ],
+        "contacts": ["admin@site-b.email.foo"],
+        "exclude":true
+    },
+    {
+        "name": "rule_Site-C",
+        "fields": [
+            {"field": "resource", "regex": "Site-C"}
+        ],
+        "contacts": ["admin@site-c.email.foo"],
+        "exclude":true
+    },
+    {
+        "name": "rule_Site-D",
+        "fields": [
+            {"field": "resource", "regex": "Site-D"}
+        ],
+        "contacts": ["admin@site-d.email.foo"],
+        "exclude":true
+    },
+    {
+      "name": "rule_Site-E",
+      "fields": [
+          {"field": "resource", "regex": "Site-E"}
+      ],
+        "contacts": ["admin@site-e.email.foo"],
+        "exclude":true
+    },
+      {
+        "name": "rule_Site-F",
+        "fields": [
+            {"field": "resource", "regex": "Site-F"}
+        ],
+        "contacts": ["admin@site-f.email.foo"],
+        "exclude":true
+    }
+]

--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -37,4 +37,39 @@ def test_endpoint_metric_event():
     alerta_str = json.dumps(alerta_json)
     assert(alerta_str == exp_str)
 
+# Test gocdb xml to contacts json transformation
+def test_gocdb_to_contacts():
+
+    xmlfn = "./tests/files/gocdb-foo.xml"
+    jsonfn = "./tests/files/contacts.json"
+
+
+    with open(jsonfn,'r') as jsonfile:
+        jsondata = jsonfile.read().replace('\n', '')
+        expJson = json.loads(jsondata)
+
+        with open(xmlfn, 'r') as xmlfile:
+            xmldata = xmlfile.read().replace('\n', '')
+            contacts = argoalert.gocdb_to_contacts(xmldata)
+            assert (contacts == expJson)
+
+# Test contacts to alerta transformation
+def test_contacts_to_alerta():
+
+    cfn = "./tests/files/contacts.json"
+    rfn = "./tests/files/rules.json"
+
+
+    with open(rfn,'r') as ruleJson:
+        ruleData = ruleJson.read().replace('\n', '')
+        expJson = json.loads(ruleData)
+
+        with open(cfn, 'r') as contactJson:
+            contactData = contactJson.read().replace('\n', '')
+            contacts = json.loads(contactData)
+            rules = argoalert.contacts_to_alerta(contacts)
+            rulesOut = json.dumps(rules,sort_keys=True)
+            expOut = json.dumps(expJson,sort_keys=True)
+            assert(rulesOut == expOut)
+
 


### PR DESCRIPTION
- Refactor configuration file. Add `[gocdb]` section and `[alerta]:mail-rule` parameter
- Add method for connecting to gocdb api endpoint and getting contact-information data
- Add method for transforming gocdb xml data to generic contact json data
- Add method for transforming generic contact json data to alerta-mailer rules 
- Add method to output generated rules to file
- Add unit tests
- Update readme
