### PR TITLE
ARGO-945 Fix endpoint_group field. Lowercase status field values

### DIFF
--- a/argoalert/argoalert.py
+++ b/argoalert/argoalert.py
@@ -15,11 +15,11 @@ def transform(argo_event, environment):
     Return:
         obj: Json representation of an alerta alert
     """
-    status = argo_event["status"]
+    status = argo_event["status"].lower()
     hostname = argo_event["hostname"]
     metric = argo_event["metric"]
     summary = argo_event["summary"]
-    group = argo_event["group"]
+    group = argo_event["endpoint_group"]
     etype = argo_event["type"]
     service = argo_event["service"]
 

--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -3,7 +3,7 @@ from argoalert import argoalert
 
 # Test the transformation of argo endpoint group status event to alerta alert representation
 def test_endpoint_group_event():
-    argo_str='{"status":"ok","group":"SITEA","metric":"httpd.memory","service":"httpd","hostname":"webserver01","summary":"foo","type":"endpoint_group"}'
+    argo_str='{"status":"OK","endpoint_group":"SITEA","metric":"httpd.memory","service":"httpd","hostname":"webserver01","summary":"foo","type":"endpoint_group"}'
     exp_str = '{"resource": "SITEA", "severity": "ok", "service": ["endpoint_group"], "text": "foo", "environment": "devel", "event": "status"}'
     argo_json = json.loads(argo_str)
     alerta_json = argoalert.transform(argo_json,"devel")
@@ -12,7 +12,7 @@ def test_endpoint_group_event():
 
 # Test the transformation of argo service status event to alerta alert representation
 def test_service_event():
-    argo_str='{"status":"ok","group":"SITEA","metric":"httpd.memory","service":"httpd","hostname":"webserver01","summary":"foo","type":"service"}'
+    argo_str='{"status":"OK","endpoint_group":"SITEA","metric":"httpd.memory","service":"httpd","hostname":"webserver01","summary":"foo","type":"service"}'
     exp_str = '{"resource": "SITEA/httpd", "severity": "ok", "service": ["service"], "text": "foo", "environment": "devel", "event": "status"}'
     argo_json = json.loads(argo_str)
     alerta_json = argoalert.transform(argo_json,"devel")
@@ -21,7 +21,7 @@ def test_service_event():
 
 # Test the transformation of argo endpoint status event to alerta alert representation
 def test_endpoint_event():
-    argo_str='{"status":"ok","group":"SITEA","metric":"httpd.memory","service":"httpd","hostname":"webserver01","summary":"foo","type":"endpoint"}'
+    argo_str='{"status":"OK","endpoint_group":"SITEA","metric":"httpd.memory","service":"httpd","hostname":"webserver01","summary":"foo","type":"endpoint"}'
     exp_str = '{"resource": "SITEA/httpd/webserver01", "severity": "ok", "service": ["endpoint"], "text": "foo", "environment": "devel", "event": "status"}'
     argo_json = json.loads(argo_str)
     alerta_json = argoalert.transform(argo_json,"devel")
@@ -30,7 +30,7 @@ def test_endpoint_event():
 
 # Test the transformation of argo metric status event to alerta alert representation
 def test_endpoint_metric_event():
-    argo_str='{"status":"ok","group":"SITEA","metric":"httpd.memory","service":"httpd","hostname":"webserver01","summary":"foo","type":"metric"}'
+    argo_str='{"status":"OK","endpoint_group":"SITEA","metric":"httpd.memory","service":"httpd","hostname":"webserver01","summary":"foo","type":"metric"}'
     exp_str = '{"resource": "SITEA/httpd/webserver01/httpd.memory", "severity": "ok", "service": ["metric"], "text": "foo", "environment": "devel", "event": "status"}'
     argo_json = json.loads(argo_str)
     alerta_json = argoalert.transform(argo_json,"devel")


### PR DESCRIPTION
# Issues
- argo-alert should expect to find `endpoint_group` field in status schema instead of `group` field. 
- argo status results are in uppercase form ('OK' ,'WARNING' etc.), but lowercase form is automatically recognized by alerting system ('ok', 'warning', etc.)

# Fix
- Fix `endpoint_group` field name
- Lowercase `status` field values 
