### PR TITLE
ARGO-1002 Set Content-Type header when publishing to alerta

### DIFF
--- a/argoalert/argoalert.py
+++ b/argoalert/argoalert.py
@@ -69,9 +69,12 @@ def read_and_send(message, environment, alerta_url, alerta_token):
         return
 
     logging.info("Attempting to send alert:" + json.dumps(alerta))
-    headers = {'Authorization': 'Key ' + alerta_token}
+    headers = {'Authorization': 'Key ' + alerta_token,
+               'Content-Type': 'application/json'}
+
     r = requests.post(alerta_url + "/alert", headers=headers,
                       data=json.dumps(alerta))
+    
     if r.status_code == 201:
         logging.info("Alert send to alerta successfully")
     else:


### PR DESCRIPTION
Alerta requires `Content-Type` header set to `application/json` when publishing to alerta server