### PR TITLE
ARGO-996 Add ability to generate rules using a group of test emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ To run argo-alert publisher:
 To run argo-alert mail rule generator:
 
     $ argo-alert-rulegen -c /path/to/argo-alert.conf
+    
+Using test-emails
+-----------------
+For testing purposes if you want to distribute notifications using a list
+of your own email aliases (before using client contact emails) issue:
+
+    $ argo-alert-rulegen -c /path/to/argo-alert.conf --test-emails test01@email.foo,test02@email.foo,test03@email.foo
+
+The rule list will be generated using the configured client sources but each client
+email will be replaced (using round-robin method) by a test-email (as defined in the cli arg list)
 
 Run tests
 ---------

--- a/argoalert/argoalert.py
+++ b/argoalert/argoalert.py
@@ -105,7 +105,7 @@ def start_listening(environment, kafka_endpoints, kafka_topic,
         read_and_send(message, environment, alerta_endpoint, alerta_token)
 
 
-def gocdb_to_contacts(gocdb_xml, use_notif_flag):
+def gocdb_to_contacts(gocdb_xml, use_notif_flag, test_emails):
     """Transform gocdb xml schema info on generic contacts json information
 
     Args:
@@ -118,7 +118,9 @@ def gocdb_to_contacts(gocdb_xml, use_notif_flag):
     xmldoc = parseString(gocdb_xml)
     contacts = []
     clist = xmldoc.getElementsByTagName("CONTACT_EMAIL")
-    for indx, item in enumerate(clist):
+
+    indx = 0
+    for item in clist:
 
         # By default accept all contacts
         notify_val = 'Y'
@@ -143,7 +145,12 @@ def gocdb_to_contacts(gocdb_xml, use_notif_flag):
                 continue
 
             c["name"] = name_tags[0].firstChild.nodeValue
-            c["email"] = item.firstChild.nodeValue
+
+            if test_emails is None:
+                c["email"] = item.firstChild.nodeValue
+            else:
+                c["email"] = test_emails[indx % len(test_emails)]
+                indx = indx + 1
 
             contacts.append(c)
 

--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -26,19 +26,23 @@ def main(args=None):
 
     logging.basicConfig(level=log_level)
 
+    test_emails = None
+    if args.test_emails is not None:
+        test_emails = args.test_emails.split(',')
+
     # Get site data from gocdb
     top_url = gocdb_api + top_req
     gocdb_site_xml = argoalert.get_gocdb(top_url, ca_bundle, hostcert, hostkey, verify)
 
     # Convert top-level gocdb xml data to contacts object
-    top_contacts = argoalert.gocdb_to_contacts(gocdb_site_xml, use_notif_flag)
+    top_contacts = argoalert.gocdb_to_contacts(gocdb_site_xml, use_notif_flag, test_emails)
 
     # Get sub level contact data from gocdb
     sub_url = gocdb_api + sub_req
     gocdb_service_xml = argoalert.get_gocdb(sub_url, ca_bundle, hostcert, hostkey, verify)
 
     # Convert sub-level site gocdb xml data to contacts object
-    sub_contacts = argoalert.gocdb_to_contacts(gocdb_service_xml, use_notif_flag)
+    sub_contacts = argoalert.gocdb_to_contacts(gocdb_service_xml, use_notif_flag, test_emails)
 
     # merge site and service contacts
     contacts = top_contacts + sub_contacts
@@ -57,6 +61,8 @@ if __name__ == "__main__":
     arg_parser.add_argument(
         "-c", "--config", help="config", dest="config", metavar="string",
         required="TRUE")
+    arg_parser.add_argument(
+        "-t", "--test-emails", help="test-emails", dest="test_emails", metavar="string")
 
     # Parse the command line arguments accordingly and introduce them to
     # main...

--- a/tests/files/sg_rules_test_emails.json
+++ b/tests/files/sg_rules_test_emails.json
@@ -1,0 +1,26 @@
+[
+    {
+        "name": "rule_SG_A",
+        "fields": [
+            {"field": "resource", "regex": "SG_A"}
+        ],
+        "contacts": ["test1@email.foo"],
+        "exclude":true
+    },
+    {
+        "name": "rule_SG_C",
+        "fields": [
+            {"field": "resource", "regex": "SG_C"}
+        ],
+        "contacts": ["test2@email.foo"],
+        "exclude":true
+    },
+    {
+        "name": "rule_SG_D",
+        "fields": [
+            {"field": "resource", "regex": "SG_D"}
+        ],
+        "contacts": ["test1@email.foo"],
+        "exclude":true
+    }
+]

--- a/tests/files/site_rules_test_emails.json
+++ b/tests/files/site_rules_test_emails.json
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "rule_Site-A",
+        "fields": [
+            {"field": "resource", "regex": "Site-A"}
+        ],
+        "contacts": ["test1@email.foo"],
+        "exclude":true
+    },
+    {
+        "name": "rule_Site-B",
+        "fields": [
+            {"field": "resource", "regex": "Site-B"}
+        ],
+        "contacts": ["test2@email.foo"],
+        "exclude":true
+    },
+    {
+        "name": "rule_Site-D",
+        "fields": [
+            {"field": "resource", "regex": "Site-D"}
+        ],
+        "contacts": ["test3@email.foo"],
+        "exclude":true
+    },
+    {
+        "name": "rule_Site-F",
+        "fields": [
+            {"field": "resource", "regex": "Site-F"}
+        ],
+        "contacts": ["test1@email.foo"],
+        "exclude":true
+    }
+]

--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -60,7 +60,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                 exp_json = json.loads(json_data)
 
                 use_notif_flag = True
-                contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag)
+                contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, None)
 
                 self.assertEqual(contacts, exp_json)
 
@@ -70,7 +70,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                 exp_json = json.loads(json_data)
 
                 use_notif_flag = False
-                contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag)
+                contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, None)
 
                 self.assertEqual(contacts, exp_json)
 
@@ -90,7 +90,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                 exp_json = json.loads(json_data)
 
                 use_notif_flag = True
-                contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag)
+                contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, None)
 
                 self.assertEqual(contacts, exp_json)
 
@@ -100,7 +100,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                 exp_json = json.loads(json_data)
 
                 use_notif_flag = False
-                contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag)
+                contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, None)
 
                 self.assertEqual(contacts, exp_json)
 
@@ -138,5 +138,47 @@ class TestArgoAlertMethods(unittest.TestCase):
                 rules_out = json.dumps(rules, sort_keys=True)
                 exp_out = json.dumps(exp_json, sort_keys=True)
                 self.assertEqual(rules_out, exp_out)
+
+    # Test gocdb xml with test emails to final rules
+    def test_site_gocdb_test_mails(self):
+        xml_fn = "./tests/files/site_gocdb.xml"
+        site_rules_fn = "./tests/files/site_rules_test_emails.json"
+
+        with open(xml_fn, 'r') as xml_file:
+            xml_data = xml_file.read().replace('\n', '')
+
+            # Select contacts using notification flag on
+            with open(site_rules_fn, 'r') as json_file:
+                json_data = json_file.read().replace('\n', '')
+                exp_json = json.loads(json_data)
+
+                use_notif_flag = True
+                test_emails = ["test1@email.foo", "test2@email.foo", "test3@email.foo"]
+                contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, test_emails)
+
+                rules = argoalert.contacts_to_alerta(contacts)
+                print rules
+                self.assertEqual(exp_json, rules)
+
+    # Test gocdb xml with test emails to final rules
+    def test_sg_gocdb_test_mails(self):
+        xml_fn = "./tests/files/sg_gocdb.xml"
+        site_rules_fn = "./tests/files/sg_rules_test_emails.json"
+
+        with open(xml_fn, 'r') as xml_file:
+            xml_data = xml_file.read().replace('\n', '')
+
+            # Select contacts using notification flag on
+            with open(site_rules_fn, 'r') as json_file:
+                json_data = json_file.read().replace('\n', '')
+                exp_json = json.loads(json_data)
+
+                use_notif_flag = True
+                test_emails = ["test1@email.foo", "test2@email.foo"]
+                contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, test_emails)
+
+                rules = argoalert.contacts_to_alerta(contacts)
+                print rules
+                self.assertEqual(exp_json, rules)
 
 


### PR DESCRIPTION
# Issue
Sometimes in argo-alert rule generator is desirable to replace official client contact-emails with a list of test emails for testing purposes (to test and monitor notification email distribution). 

# Implementation
Add optional `-t` or `--test-emails` cli argument which accepts a list of emails such as: `test01@email.foo,test02@email.foo` 
Given this argument during rule generation, replace each client email with a test-one (using round robin method)