### PR TITLE
ARGO-1066 Add basic http auth support in rule generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The configuration file for argo-alert provides a `[gocdb]` section to configure 
 and the required certificate parameters for access. The `mail-rules` parameter in `[alerta]` section
 specifies the alerta-mailer rule filename for output.  
 
+Access to gocdb api endpoint support http basic auth or certificate-based. In the case of
+http basic authenticaation (when in config `auth_method=basic` ) `username` and `password` parameters 
+should be set in config file. In the case of certificate-based auth (when in config `auth_method=cert` )
+`hostcert` and `hostkey` parameters should be set.  
 
 Installation / Usage
 --------------------
@@ -60,6 +64,12 @@ Or clone the repo:
 argoalert requires a configuration file with the following options:
 ```
 [gocdb]
+# auth_method to be used when contacting gocdb api: basic-auth or cert
+auth_method=cert
+# username for basic auth
+username=
+# password for basic auth
+password=
 # Path to godcb endpoint
 api=https://gocdb-url.example.foo
 # Path to ca bundle folder
@@ -96,6 +106,7 @@ mail-rules=/home/root/alerta-rules-101
 [logging]
 # loggin level
 level = INFO
+
 
 ```
 

--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -13,16 +13,31 @@ def main(args=None):
     parser = SafeConfigParser()
     parser.read(args.config)
 
+    # Initialize authorization info object
+    auth_info = dict()
+
+    auth_method = parser.get("gocdb", "auth_method")
+    if auth_method == "cert":
+        auth_info["method"] = "cert"
+
+        auth_info["cert"] = parser.get("gocdb", "hostcert")
+        auth_info["key"] = parser.get("gocdb", "hostkey")
+    elif auth_method == "basic":
+        auth_info["method"] = "basic"
+        auth_info["user"] = parser.get("gocdb", "username")
+        auth_info["pass"] = parser.get("gocdb", "password")
+
     gocdb_api = parser.get("gocdb", "api")
-    ca_bundle = parser.get("gocdb", "cabundle")
-    hostcert = parser.get("gocdb", "hostcert")
-    hostkey = parser.get("gocdb", "hostkey")
     verify = parser.getboolean("gocdb", "verify")
+    ca_bundle = None
+    if verify:
+        ca_bundle = parser.get("gocdb", "cabundle")
     use_notif_flag = parser.getboolean("gocdb", "use_notifications_flag")
     rule_file = parser.get("alerta", "mail-rules")
     log_level = parser.get("logging", "level")
     top_req = parser.get("gocdb","top_request")
     sub_req = parser.get("gocdb","sub_request")
+
 
     logging.basicConfig(level=log_level)
 
@@ -32,14 +47,14 @@ def main(args=None):
 
     # Get site data from gocdb
     top_url = gocdb_api + top_req
-    gocdb_site_xml = argoalert.get_gocdb(top_url, ca_bundle, hostcert, hostkey, verify)
+    gocdb_site_xml = argoalert.get_gocdb(top_url, auth_info, ca_bundle)
 
     # Convert top-level gocdb xml data to contacts object
     top_contacts = argoalert.gocdb_to_contacts(gocdb_site_xml, use_notif_flag, test_emails)
 
     # Get sub level contact data from gocdb
     sub_url = gocdb_api + sub_req
-    gocdb_service_xml = argoalert.get_gocdb(sub_url, ca_bundle, hostcert, hostkey, verify)
+    gocdb_service_xml = argoalert.get_gocdb(sub_url, auth_info, ca_bundle)
 
     # Convert sub-level site gocdb xml data to contacts object
     sub_contacts = argoalert.gocdb_to_contacts(gocdb_service_xml, use_notif_flag, test_emails)

--- a/conf/argo-alert.conf.template
+++ b/conf/argo-alert.conf.template
@@ -1,4 +1,10 @@
 [gocdb]
+# auth_method to be used when contacting gocdb api: basic-auth or cert
+auth_method=cert
+# username for basic auth
+username=
+# password for basic auth
+password=
 # Path to godcb endpoint
 api=https://gocdb-url.example.foo
 # Path to ca bundle folder


### PR DESCRIPTION
# Issue
Some clients need to use basic http auth when accessing gocdb api 

# Implementation
- Add the ability to choose auth_method in config (`auth_method=cert || auth_method=basic`) 
- Add extra parameters for basic auth (`username`,`password`)
- Refactor method that requests contact information so as to support both auth methods
- Update docs