### PR TITLE
ARGO-1091 Fix argo-alert-publisher handling of timeout & grouptype args

### DIFF
--- a/bin/argo-alert-publisher
+++ b/bin/argo-alert-publisher
@@ -33,9 +33,7 @@ def main(args=None):
     # create alert options dictionary
     options = {"timeout": alert_timeout, "group_type": group_type}
 
-
-
-    argoalert.start_listening(environment, kafka_endpoint, kafka_topic, alerta_endpoint, alerta_token, alert_timeout, group_type)
+    argoalert.start_listening(environment, kafka_endpoint, kafka_topic, alerta_endpoint, alerta_token, options)
 
 
 if __name__ == "__main__":

--- a/conf/argo-alert.conf.template
+++ b/conf/argo-alert.conf.template
@@ -40,7 +40,7 @@ mail-rules=/home/root/alerta-rules-101
 # extra emails to be notified
 extra-emails=alert01@mail.example.foo,alert02@mail.example.foo
 # alert timeout is the time in seconds needed for the alert to be considered stale
-aleart-timeout = 3600
+alert-timeout = 3600
 # group type of the tenant's top level group used in alert generation and mail template
 group-type = Group
 


### PR DESCRIPTION
- Fix handling of timeout and grouptype arguments in exec script argo-alert-publisher. (arguments should be passed as options dic in start_listening func)
- Fix typo in configuration template