### PR TITLE
ARGO-1116 Fix handling of optional params: group-type, timeout

### DIFF
--- a/bin/argo-alert-publisher
+++ b/bin/argo-alert-publisher
@@ -24,11 +24,11 @@ def main(args=None):
     # default alert timeout value
     alert_timeout = 3600
     if parser.has_option("alerta", "alert-timeout"):
-        alert_timeout = parser.get("alerta", "alert-timeout")
+        alert_timeout = int(parser.get("alerta", "alert-timeout"))
 
     group_type = "Group"
     if parser.has_option("alerta", "group-type"):
-        alert_timeout = parser.get("alerta", "group-type")
+        group_type = parser.get("alerta", "group-type")
 
     # create alert options dictionary
     options = {"timeout": alert_timeout, "group_type": group_type}


### PR DESCRIPTION
## Fixes
- Optional timeout  param should be parsed as integer
- Fix group-type param overwriting timeout value
 

