### PR TITLE
ARGO-1484 Special case for contact generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ of your own email aliases (before using client contact emails) issue:
 The rule list will be generated using the configured client sources but each client
 email will be replaced (using round-robin method) by a test-email (as defined in the cli arg list)
 
+Ingore notification flag for groups (top-level)
+-----------------------------------------------
+For the special case that top level groups have different notification flag requirement the special cli parameter 
+`--group-notification-flag` or `-g` can be used and set to `true` or `false`. 
+For example if config file honors the use of notification flag in general but user needs to turn it of for top level 
+groups, can issue:
+
+    $ argo-alert-rulegen -c /path/to/argo-alert.conf -g false
+
+The rule list will be generated using the configured client sources but each client
+email will be replaced (using round-robin method) by a test-email (as defined in the cli arg list)
+
+
 Run tests
 ---------
 

--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -51,12 +51,19 @@ def main(args=None):
     if args.test_emails is not None:
         test_emails = args.test_emails.split(',')
 
+    group_notify_flag = use_notif_flag
+    if args.group_notify_flag is not None:
+        if args.group_notify_flag.lower() in ('true','yes','y'):
+            group_notify_flag = True
+        else: 
+            group_notify_flag = False
+
     # Get site data from gocdb
     top_url = gocdb_api + top_req
     gocdb_site_xml = argoalert.get_gocdb(top_url, auth_info, ca_bundle)
 
     # Convert top-level gocdb xml data to contacts object
-    top_contacts = argoalert.gocdb_to_contacts(gocdb_site_xml, use_notif_flag, test_emails)
+    top_contacts = argoalert.gocdb_to_contacts(gocdb_site_xml, group_notify_flag, test_emails)
 
     # Get sub level contact data from gocdb
     sub_url = gocdb_api + sub_req
@@ -84,6 +91,8 @@ if __name__ == "__main__":
         required="TRUE")
     arg_parser.add_argument(
         "-t", "--test-emails", help="test-emails", dest="test_emails", metavar="string")
+    arg_parser.add_argument(
+        "-g", "--group-notification-flag", help="use or not the notification flag in top level groups", dest="group_notify_flag", metavar="string")
 
     # Parse the command line arguments accordingly and introduce them to
     # main...


### PR DESCRIPTION
# Goals
Better handling of low level items (service endpoint groups) when generating contact information from gocdb
Give the ability to independently  ignore notification flag in top level groups

# Implementation 
- Refactor gocdb_to_contacts method to better handle information of lower level items
- Refactor rule generation method to fix regexp for lower level items
- Add optional flag to  independently  ignore notification flag in top level items (Use boolean `-g` or `--group-notify-flag` cli argument)
