### PR TITLE
 ARGO-1715 Consolidate alerts for endpoints that belong to multiple endpoin group

### DIFF
--- a/argoalert/argoalert.py
+++ b/argoalert/argoalert.py
@@ -193,8 +193,8 @@ def transform(argo_event, environment, grouptype, timeout, ui_endpoint, report):
             attributes["_alert_url"] = ui_service_url(ui_endpoint, report, ts_monitored, group)
     elif etype == "endpoint":
         alerta_service.append("endpoint")
-        resource = group + "/" + service + "/" + hostname
-        text = "[ {0} ] - Endpoint {1} is {2}".format(environment.upper(), hostname, status.upper())
+        resource = service + "/" + hostname
+        text = "[ {0} ] - Endpoint {1}/{2} is {3}".format(environment.upper(), hostname, service, status.upper())
         if ui_endpoint is not "":
             attributes["_alert_url"] = ui_endpoint_url(ui_endpoint, report, ts_monitored, group, service)
     elif etype == "metric":

--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -56,8 +56,8 @@ class TestArgoAlertMethods(unittest.TestCase):
         exp_str = '{"attributes": {"_alert_url": "http://ui.argo.foo/lavoisier/status_report-endpoints?site=SITEA&service=httpd&start_date=2018-04-21T00:00:00Z&end_date=2018-04-24T14:35:33Z&report=Critical&accept=html", '\
                   '"_endpoint": "webserver01", "_group": "SITEA", "_group_type": "", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
                   '"_repeat": "false", "_service": "httpd", "_status_egroup": "", "_status_endpoint": "", "_status_metric": "", "_status_service": "", "_ts_monitored": "2018-04-24T13:35:33Z", "_ts_processed": ""}, "environment": ' \
-                  '"devel", "event": "endpoint_status", "resource": "SITEA/httpd/webserver01", "service": [' \
-                  '"endpoint"], "severity": "ok", "text": "[ DEVEL ] - Endpoint webserver01 is OK", "timeout": ' \
+                  '"devel", "event": "endpoint_status", "resource": "httpd/webserver01", "service": [' \
+                  '"endpoint"], "severity": "ok", "text": "[ DEVEL ] - Endpoint webserver01/httpd is OK", "timeout": ' \
                   '122}'
 
         argo_json = json.loads(argo_str)


### PR DESCRIPTION
:warning: To be merged after: https://github.com/ARGOeu/argo-alert/pull/27

# implementation
Generate a resource identified by removing the endpoint_group information. All endpoint status events generated for different groups will generate a specific alert referring to a specific service+host-name