### PR TITLE
ARGO-1710 publish group item status info to alerta

### DIFF
--- a/argoalert/argoalert.py
+++ b/argoalert/argoalert.py
@@ -174,6 +174,25 @@ def transform(argo_event, environment, grouptype, timeout, ui_endpoint, report):
     else:
         attributes["_status_egroup"] = ""
 
+
+    # add group endpoint statuses
+
+    if "group_endpoints" in argo_event:
+        attributes["_group_endpoints"] = argo_event["group_endpoints"]
+    else:
+        attributes["_group_endpoints"] = ""
+
+    if "group_statuses" in argo_event:
+        attributes["_group_statuses"] = argo_event["group_statuses"]
+    else:
+        attributes["_group_statuses"] = ""
+
+    if "group_services" in argo_event:
+        attributes["_group_services"] = argo_event["group_services"]
+    else:
+        attributes["_group_services"] = ""
+
+
     # add mon messages
     attributes["_mon_summary"] = argo_event["summary"]
     attributes["_mon_message"] = argo_event["message"] 

--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -18,7 +18,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                  '"hostname":"webserver01","summary":"foo","type":"endpoint_group", "repeat": "false", ' \
                  '"ts_monitored":"2018-04-24T13:35:33Z", "ts_processed":"", "message":"", "summary":""} '
         exp_str = '{"attributes": {"_alert_url": "https://ui.argo.foo/lavoisier/status_report-site?site=SITEA&start=2018-04-21&end=2018-04-24&report=Critical&accept=html", '\
-                  '"_endpoint": "webserver01", "_group": "SITEA", "_group_type": "Project", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
+                  '"_endpoint": "webserver01", "_group": "SITEA", "_group_endpoints": "", "_group_services": "", "_group_statuses": "", "_group_type": "Project", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
                   '"_repeat": "false", "_service": "httpd", "_status_egroup": "", "_status_endpoint": "", "_status_metric": "", "_status_service": "", "_ts_monitored": "2018-04-24T13:35:33Z", "_ts_processed": ""}, "environment": ' \
                   '"devel", "event": "endpoint_group_status", "resource": "SITEA", "service": ["endpoint_group"], ' \
                   '"severity": "ok", "text": "[ DEVEL ] - Project SITEA is OK", "timeout": 20}'
@@ -37,7 +37,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                    '"ts_processed":"", "message":"", "summary":""} '
         exp_str = '{"attributes": {"_alert_url": "https://ui.argo.foo/lavoisier/status_report-sf?' \
                    'site=SITEA&start_date=2018-04-21T00:00:00Z&end_date=2018-04-24T14:35:33Z&report=Critical&accept=html", ' \
-                   '"_endpoint": "webserver01", "_group": "SITEA", "_group_type": "", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", "_repeat": "false", ' \
+                   '"_endpoint": "webserver01", "_group": "SITEA", "_group_endpoints": "", "_group_services": "", "_group_statuses": "", "_group_type": "", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", "_repeat": "false", ' \
                    '"_service": "httpd", "_status_egroup": "", "_status_endpoint": "", "_status_metric": "", "_status_service": "", "_ts_monitored": "2018-04-24T13:35:33Z", "_ts_processed": ""}, ' \
                    '"environment": "devel", "event": "service_status", "resource": "SITEA/httpd", "service": ["service"], ' \
                    '"severity": "ok", "text": "[ DEVEL ] - Service httpd is OK", "timeout": 32}'
@@ -54,7 +54,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                  '"hostname":"webserver01","summary":"foo","type":"endpoint", "repeat": "false", "ts_monitored":"2018-04-24T13:35:33Z", ' \
                  '"ts_processed":"", "message":"", "summary":""} '
         exp_str = '{"attributes": {"_alert_url": "http://ui.argo.foo/lavoisier/status_report-endpoints?site=SITEA&service=httpd&start_date=2018-04-21T00:00:00Z&end_date=2018-04-24T14:35:33Z&report=Critical&accept=html", '\
-                  '"_endpoint": "webserver01", "_group": "SITEA", "_group_type": "", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
+                  '"_endpoint": "webserver01", "_group": "SITEA", "_group_endpoints": "", "_group_services": "", "_group_statuses": "", "_group_type": "", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
                   '"_repeat": "false", "_service": "httpd", "_status_egroup": "", "_status_endpoint": "", "_status_metric": "", "_status_service": "", "_ts_monitored": "2018-04-24T13:35:33Z", "_ts_processed": ""}, "environment": ' \
                   '"devel", "event": "endpoint_status", "resource": "httpd/webserver01", "service": [' \
                   '"endpoint"], "severity": "ok", "text": "[ DEVEL ] - Endpoint webserver01/httpd is OK", "timeout": ' \
@@ -70,7 +70,7 @@ class TestArgoAlertMethods(unittest.TestCase):
     def test_endpoint_metric_event(self):
         argo_str = '{"status":"OK","endpoint_group":"SITEA","metric":"httpd.memory","service":"httpd","hostname":"webserver01","summary":"foo","type":"metric", "repeat": "false", "ts_monitored":"2018-04-24T13:35:33Z", "ts_processed":"", "message":"", "summary":""}'
         exp_str = '{"attributes": {"_alert_url": "http://ui.argo.foo/lavoisier/status_report-metrics?site=SITEA&service=httpd&endpoint=webserver01&start_date=2018-04-21T00:00:00Z&end_date=2018-04-24T14:35:33Z&report=Critical&overview=mod&accept=html", '\
-                  '"_endpoint": "webserver01", "_group": "SITEA", "_group_type": "", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
+                  '"_endpoint": "webserver01", "_group": "SITEA", "_group_endpoints": "", "_group_services": "", "_group_statuses": "", "_group_type": "", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
                   '"_repeat": "false", "_service": "httpd", "_status_egroup": "", "_status_endpoint": "", "_status_metric": "", "_status_service": "", "_ts_monitored": "2018-04-24T13:35:33Z", "_ts_processed": ""}, "environment": ' \
                   '"devel", "event": "metric_status", "resource": "SITEA/httpd/webserver01/httpd.memory", "service": [' \
                   '"metric"], "severity": "ok", "text": "[ DEVEL ] - Metric httpd.memory@(webserver01:httpd) is OK", ' \


### PR DESCRIPTION
:warning: to be merged after https://github.com/ARGOeu/argo-alert/pull/28

# Implementation 
Extend argo-ams-publisher to publish information about group endpoint statuses 