### PR TITLE
ARGO-1793 Fix ui_urls in alert mails to point correctly to the new web_ui

### DIFF
--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -17,7 +17,7 @@ class TestArgoAlertMethods(unittest.TestCase):
         argo_str='{"status":"OK","endpoint_group":"SITEA","metric":"httpd.memory","service":"httpd",' \
                  '"hostname":"webserver01","summary":"foo","type":"endpoint_group", "repeat": "false", ' \
                  '"ts_monitored":"2018-04-24T13:35:33Z", "ts_processed":"", "message":"", "summary":""} '
-        exp_str = '{"attributes": {"_alert_url": "https://ui.argo.foo/lavoisier/status_report-site?site=SITEA&start=2018-04-21&end=2018-04-24&report=Critical&accept=html", '\
+        exp_str = '{"attributes": {"_alert_url": "https://ui.argo.foo/devel/report-status/Critical/PROJECTS/SITEA?start=2018-04-21&end=2018-04-24", '\
                   '"_endpoint": "webserver01", "_group": "SITEA", "_group_endpoints": "", "_group_services": "", "_group_statuses": "", "_group_type": "Project", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
                   '"_repeat": "false", "_service": "httpd", "_status_egroup": "", "_status_endpoint": "", "_status_metric": "", "_status_service": "", "_ts_monitored": "2018-04-24T13:35:33Z", "_ts_processed": ""}, "environment": ' \
                   '"devel", "event": "endpoint_group_status", "resource": "SITEA", "service": ["endpoint_group"], ' \
@@ -35,8 +35,7 @@ class TestArgoAlertMethods(unittest.TestCase):
         argo_str = '{"status":"OK","endpoint_group":"SITEA","metric":"httpd.memory","service":"httpd",' \
                    '"hostname":"webserver01","summary":"foo","type":"service", "repeat": "false", "ts_monitored":"2018-04-24T13:35:33Z", ' \
                    '"ts_processed":"", "message":"", "summary":""} '
-        exp_str = '{"attributes": {"_alert_url": "https://ui.argo.foo/lavoisier/status_report-sf?' \
-                   'site=SITEA&start_date=2018-04-21T00:00:00Z&end_date=2018-04-24T14:35:33Z&report=Critical&accept=html", ' \
+        exp_str = '{"attributes": {' \
                    '"_endpoint": "webserver01", "_group": "SITEA", "_group_endpoints": "", "_group_services": "", "_group_statuses": "", "_group_type": "", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", "_repeat": "false", ' \
                    '"_service": "httpd", "_status_egroup": "", "_status_endpoint": "", "_status_metric": "", "_status_service": "", "_ts_monitored": "2018-04-24T13:35:33Z", "_ts_processed": ""}, ' \
                    '"environment": "devel", "event": "service_status", "resource": "SITEA/httpd", "service": ["service"], ' \
@@ -50,18 +49,18 @@ class TestArgoAlertMethods(unittest.TestCase):
 
     # # Test the transformation of argo endpoint status event to alerta alert representation
     def test_endpoint_event(self):
-        argo_str='{"status":"OK","endpoint_group":"SITEA","metric":"httpd.memory","service":"httpd",' \
+        argo_str='{"status":"OK", "endpoint_group":"SITEA","metric":"httpd.memory","service":"httpd",' \
                  '"hostname":"webserver01","summary":"foo","type":"endpoint", "repeat": "false", "ts_monitored":"2018-04-24T13:35:33Z", ' \
                  '"ts_processed":"", "message":"", "summary":""} '
-        exp_str = '{"attributes": {"_alert_url": "http://ui.argo.foo/lavoisier/status_report-endpoints?site=SITEA&service=httpd&start_date=2018-04-21T00:00:00Z&end_date=2018-04-24T14:35:33Z&report=Critical&accept=html", '\
-                  '"_endpoint": "webserver01", "_group": "SITEA", "_group_endpoints": "", "_group_services": "", "_group_statuses": "", "_group_type": "", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
+        exp_str = '{"attributes": {"_alert_url": "http://ui.argo.foo/devel/report-status/Critical/SITES/SITEA/httpd/webserver01?start=2018-04-21&end=2018-04-24", '\
+                  '"_endpoint": "webserver01", "_group": "SITEA", "_group_endpoints": "", "_group_services": "", "_group_statuses": "", "_group_type": "Site", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
                   '"_repeat": "false", "_service": "httpd", "_status_egroup": "", "_status_endpoint": "", "_status_metric": "", "_status_service": "", "_ts_monitored": "2018-04-24T13:35:33Z", "_ts_processed": ""}, "environment": ' \
                   '"devel", "event": "endpoint_status", "resource": "httpd/webserver01", "service": [' \
                   '"endpoint"], "severity": "ok", "text": "[ DEVEL ] - Endpoint webserver01/httpd is OK", "timeout": ' \
                   '122}'
 
         argo_json = json.loads(argo_str)
-        alerta_json = argoalert.transform(argo_json, "devel", "", 122,"ui.argo.foo","Critical")
+        alerta_json = argoalert.transform(argo_json, "devel", "Site", 122,"ui.argo.foo","Critical")
         alerta_str = json.dumps(alerta_json, sort_keys=True)
 
         self.assertEqual(alerta_str, exp_str)
@@ -69,7 +68,7 @@ class TestArgoAlertMethods(unittest.TestCase):
     # # Test the transformation of argo metric status event to alerta alert representation
     def test_endpoint_metric_event(self):
         argo_str = '{"status":"OK","endpoint_group":"SITEA","metric":"httpd.memory","service":"httpd","hostname":"webserver01","summary":"foo","type":"metric", "repeat": "false", "ts_monitored":"2018-04-24T13:35:33Z", "ts_processed":"", "message":"", "summary":""}'
-        exp_str = '{"attributes": {"_alert_url": "http://ui.argo.foo/lavoisier/status_report-metrics?site=SITEA&service=httpd&endpoint=webserver01&start_date=2018-04-21T00:00:00Z&end_date=2018-04-24T14:35:33Z&report=Critical&overview=mod&accept=html", '\
+        exp_str = '{"attributes": {' \
                   '"_endpoint": "webserver01", "_group": "SITEA", "_group_endpoints": "", "_group_services": "", "_group_statuses": "", "_group_type": "", "_metric": "httpd.memory", "_mon_message": "", "_mon_summary": "", ' \
                   '"_repeat": "false", "_service": "httpd", "_status_egroup": "", "_status_endpoint": "", "_status_metric": "", "_status_service": "", "_ts_monitored": "2018-04-24T13:35:33Z", "_ts_processed": ""}, "environment": ' \
                   '"devel", "event": "metric_status", "resource": "SITEA/httpd/webserver01/httpd.memory", "service": [' \


### PR DESCRIPTION
:warning: to be merged after https://github.com/ARGOeu/argo-alert/pull/29

# Issue
argo alert mails contained links that don't work with the new argo web ui

# Fix
- Remove old url generation for service and metrics (we don't generate such events anymore)
- Change url generation patterns for endpoint group and endpoint events
- Update unit tests