### PR TITLE
ARGO-1853 Add additional mail-rule checking alert environment

### DIFF
--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -58,6 +58,11 @@ def main(args=None):
         else: 
             group_notify_flag = False
 
+    environment = None
+    if parser.has_option("alerta", "environment"):
+       environment = parser.get("alerta","environment")
+
+
     # Get site data from gocdb
     top_url = gocdb_api + top_req
     gocdb_site_xml = argoalert.get_gocdb(top_url, auth_info, ca_bundle)
@@ -76,7 +81,7 @@ def main(args=None):
     contacts = top_contacts + sub_contacts
 
     # Convert contacts to alerta mail rules
-    rules = argoalert.contacts_to_alerta(contacts, extra_emails)
+    rules = argoalert.contacts_to_alerta(contacts, extra_emails, environment)
 
     # Save rules to alerta mailer rule file
     argoalert.write_rules(rules, rule_file)


### PR DESCRIPTION
# Issue 
Provide additional fail-safe and narrowing down in mail-rules from tenant to tenant. Right internally some tenants might use similar names in groups/services that could create similar rules when sending emails. Provide an additional field check on each rule that maps to the specific tenant. 

# Solution
Each alert has an environment field that maps exactly to the tenant name. 
Add an additional field check that indeed 'environment' == '{{tenant_name}}' on each mail rule 

# Implementation 
- [x] Add environment check to field rules in `contacts_to_alerta()` function 
- [x] Read environment option from config and provided it to the `contacts_to_alerta()` function in the rule generator script

