### PR TITLE
 ARGO-1846 Move argo-alert to python 3.x

### DIFF
--- a/argoalert/argoalert.py
+++ b/argoalert/argoalert.py
@@ -369,22 +369,22 @@ def contacts_to_alerta(contacts, extras, environment=None):
         rule_name = "rule_" + c["name"]
         if c["name"].startswith("\\/"):
             # matching item is NOT in the beginning of the resource path
-            rule_fields = [{u"field": u"resource",
-                            u"regex": "{0}($|\\/)".format(c["name"])}]
+            rule_fields = [{"field": "resource",
+                            "regex": "{0}($|\\/)".format(c["name"])}]
         else:
             # matching item is in the beginning of the resource path
-            rule_fields = [{u"field": u"resource",
-                            u"regex": "^{0}($|\\/)".format(c["name"])}]
+            rule_fields = [{"field": "resource",
+                            "regex": "^{0}($|\\/)".format(c["name"])}]
 
         if environment is not None:
             rule_fields.append(
-                {u"field": u"environment", u"regex": "{0}".format(environment)})
+                {"field": "environment", "regex": "{0}".format(environment)})
 
         rule_contacts = [c["email"]]
         rule_contacts.extend(extras)
         rule_exclude = True
-        rule = {u"name": rule_name, u"fields": rule_fields,
-                u"contacts": rule_contacts, u"exclude": rule_exclude}
+        rule = {"name": rule_name, "fields": rule_fields,
+                "contacts": rule_contacts, "exclude": rule_exclude}
         rules.append(rule)
 
     logging.info("Generated " + str(len(rules)) +

--- a/bin/argo-alert-publisher
+++ b/bin/argo-alert-publisher
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from argparse import ArgumentParser
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
 import sys
 from argoalert import argoalert
 import logging

--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from argparse import ArgumentParser
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
 import sys
 import logging
 from argoalert import argoalert

--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -58,6 +58,11 @@ def main(args=None):
         else: 
             group_notify_flag = False
 
+    environment = None
+    if parser.has_option("alerta", "environment"):
+       environment = parser.get("alerta","environment")
+
+
     # Get site data from gocdb
     top_url = gocdb_api + top_req
     gocdb_site_xml = argoalert.get_gocdb(top_url, auth_info, ca_bundle)
@@ -76,7 +81,7 @@ def main(args=None):
     contacts = top_contacts + sub_contacts
 
     # Convert contacts to alerta mail rules
-    rules = argoalert.contacts_to_alerta(contacts, extra_emails)
+    rules = argoalert.contacts_to_alerta(contacts, extra_emails, environment)
 
     # Save rules to alerta mailer rule file
     argoalert.write_rules(rules, rule_file)

--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -197,7 +197,6 @@ class TestArgoAlertMethods(unittest.TestCase):
                 contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, test_emails)
 
                 rules = argoalert.contacts_to_alerta(contacts, [])
-                print rules
                 self.assertEqual(exp_json, rules)
 
     # Test gocdb xml with test emails to final rules
@@ -218,7 +217,6 @@ class TestArgoAlertMethods(unittest.TestCase):
                 contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, test_emails)
 
                 rules = argoalert.contacts_to_alerta(contacts, [])
-                print rules
                 self.assertEqual(exp_json, rules)
 
     # Test gocdb xml with test emails and extra emails to final rules
@@ -240,7 +238,6 @@ class TestArgoAlertMethods(unittest.TestCase):
                 contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, test_emails)
 
                 rules = argoalert.contacts_to_alerta(contacts, extra_emails)
-                print rules
                 self.assertEqual(exp_json, rules)
 
 


### PR DESCRIPTION
:warning: maybe open a new py3 branch in upstream?

Move argo-alert scripts to python 3
- migration changes in code
- some tab/spaces indentation consistency clean/up