### PR TITLE
ARGO-2079 Add original contacts feature when sending to testing emails

### DIFF
--- a/tests/files/sg_rules_test_emails.json
+++ b/tests/files/sg_rules_test_emails.json
@@ -5,6 +5,7 @@
             {"field": "resource", "regex": "^SG_A($|\\/)"}
         ],
         "contacts": ["test1@email.foo"],
+        "original_contacts": ["sg_a@email.foo", "sg_x@email.foo", "sg_y@email.com"],
         "exclude":true
     },
     {
@@ -13,6 +14,7 @@
             {"field": "resource", "regex": "^SG_C($|\\/)"}
         ],
         "contacts": ["test2@email.foo"],
+        "original_contacts": ["sg_c@email.foo", "sg_w@email.foo"],
         "exclude":true
     },
     {
@@ -21,6 +23,7 @@
             {"field": "resource", "regex": "^SG_D($|\\/)"}
         ],
         "contacts": ["test1@email.foo"],
+        "original_contacts": ["sg_d@email.foo"],
         "exclude":true
     }
 ]

--- a/tests/files/site_rules_extras.json
+++ b/tests/files/site_rules_extras.json
@@ -5,6 +5,7 @@
             {"field": "resource", "regex": "^Site-A($|\\/)"}
         ],
         "contacts": ["test1@email.foo", "extra01@email.foo", "extra02@email.foo"],
+        "original_contacts": ["admin@site-a.email.foo"],
         "exclude":true
     },
     {
@@ -13,6 +14,7 @@
             {"field": "resource", "regex": "^Site-B($|\\/)"}
         ],
         "contacts": ["test2@email.foo", "extra01@email.foo", "extra02@email.foo"],
+        "original_contacts": ["admin@site-b.email.foo"],
         "exclude":true
     },
     {
@@ -21,6 +23,7 @@
             {"field": "resource", "regex": "^Site-D($|\\/)"}
         ],
         "contacts": ["test3@email.foo", "extra01@email.foo", "extra02@email.foo"],
+        "original_contacts": ["admin@site-d.email.foo"],
         "exclude":true
     },
     {
@@ -29,6 +32,7 @@
             {"field": "resource", "regex": "^Site-F($|\\/)"}
         ],
         "contacts": ["test1@email.foo", "extra01@email.foo", "extra02@email.foo"],
+        "original_contacts": ["admin@site-f.email.foo"],
         "exclude":true
     }
 ]

--- a/tests/files/site_rules_test_emails.json
+++ b/tests/files/site_rules_test_emails.json
@@ -5,6 +5,7 @@
             {"field": "resource", "regex": "^Site-A($|\\/)"}
         ],
         "contacts": ["test1@email.foo"],
+        "original_contacts": ["admin@site-a.email.foo"],
         "exclude":true
     },
     {
@@ -13,6 +14,7 @@
             {"field": "resource", "regex": "^Site-B($|\\/)"}
         ],
         "contacts": ["test2@email.foo"],
+        "original_contacts": ["admin@site-b.email.foo"],
         "exclude":true
     },
     {
@@ -21,6 +23,7 @@
             {"field": "resource", "regex": "^Site-D($|\\/)"}
         ],
         "contacts": ["test3@email.foo"],
+        "original_contacts": ["admin@site-d.email.foo"],
         "exclude":true
     },
     {
@@ -29,6 +32,7 @@
             {"field": "resource", "regex": "^Site-F($|\\/)"}
         ],
         "contacts": ["test1@email.foo"],
+        "original_contacts": ["admin@site-f.email.foo"],
         "exclude":true
     }
 ]


### PR DESCRIPTION
## Goal 
When using argo-rule-generator with test emails maintain also information about the original contacts

## Implementation
If test mode is enabled rule geneator maintains the original contacts in a new field inside each rule named `original_contacts`