### PR TITLE
ARGO-3901 Retrieve contacts from argo-web-api

### DIFF
--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -13,80 +13,127 @@ def main(args=None):
     parser = ConfigParser()
     parser.read(args.config)
 
-    feed_type = parser.get("feed","feed_type")
-    
+    feed_type = parser.get("feed", "feed_type")
 
-    # Initialize authorization info object
-    auth_info = dict()
-
-    auth_method = parser.get("gocdb", "auth_method")
-    if auth_method == "cert":
-        auth_info["method"] = "cert"
-
-        auth_info["cert"] = parser.get("gocdb", "hostcert")
-        auth_info["key"] = parser.get("gocdb", "hostkey")
-    elif auth_method == "basic":
-        auth_info["method"] = "basic"
-        auth_info["user"] = parser.get("gocdb", "username")
-        auth_info["pass"] = parser.get("gocdb", "password")
-
-    gocdb_api = parser.get("gocdb", "api")
-    verify = parser.getboolean("gocdb", "verify")
-    ca_bundle = None
-    if verify:
-        ca_bundle = parser.get("gocdb", "cabundle")
-    use_notif_flag = parser.getboolean("gocdb", "use_notifications_flag")
-    rule_file = parser.get("alerta", "mail-rules")
     log_level = parser.get("logging", "level")
-    top_req = parser.get("gocdb", "top_request")
-    sub_req = parser.get("gocdb", "sub_request")
-
-    extra_emails = []
-    # Check if configuration has extra emails defined
-    if parser.has_option("alerta", "extra-emails"):
-        extra_emails = parser.get("alerta", "extra-emails").split(",")
-
     logging.basicConfig(level=log_level)
 
-    test_emails = None
-    if args.test_emails is not None:
-        test_emails = args.test_emails.split(',')
+    if feed_type == "argo-web-api":
 
-    group_notify_flag = use_notif_flag
-    if args.group_notify_flag is not None:
-        if args.group_notify_flag.lower() in ('true', 'yes', 'y'):
-            group_notify_flag = True
-        else:
-            group_notify_flag = False
+        api_endpoint = parser.get("argo-web-api", "endpoint")
+        api_access_key = parser.get("argo-web-api", "access_key")
+        api_verify = parser.getboolean("argo-web-api", "verify")
+        api_use_notifications_flag = parser.getboolean(
+            "argo-web-api", "use_notifications_flag")
+        rule_file = parser.get("alerta", "mail-rules")
+        environment = None
+        if parser.has_option("alerta", "environment"):
+            environment = parser.get("alerta", "environment")
 
-    environment = None
-    if parser.has_option("alerta", "environment"):
-        environment = parser.get("alerta", "environment")
+        extra_emails = []
+        # Check if configuration has extra emails defined
+        if parser.has_option("alerta", "extra-emails"):
+            extra_value = parser.get("alerta", "extra-emails")
+            if extra_value:
+                extra_emails = extra_value.split(",")
 
-    # Get site data from gocdb
-    top_url = gocdb_api + top_req
-    gocdb_site_xml = argoalert.get_gocdb(top_url, auth_info, ca_bundle)
+        test_emails = None
+        if args.test_emails is not None:
+            test_emails = args.test_emails.split(',')
 
-    # Convert top-level gocdb xml data to contacts object
-    top_contacts = argoalert.gocdb_to_contacts(
-        gocdb_site_xml, group_notify_flag, test_emails)
+        # get endpoint topology
+        endpoint_topology_data = argoalert.get_argo_web_api_data(
+            api_endpoint, api_access_key, api_verify, "endpoints")
 
-    # Get sub level contact data from gocdb
-    sub_url = gocdb_api + sub_req
-    gocdb_service_xml = argoalert.get_gocdb(sub_url, auth_info, ca_bundle)
+        # get group topology
+        group_topology_data = argoalert.get_argo_web_api_data(
+            api_endpoint, api_access_key, api_verify, "groups")
 
-    # Convert sub-level site gocdb xml data to contacts object
-    sub_contacts = argoalert.gocdb_to_contacts(
-        gocdb_service_xml, use_notif_flag, test_emails)
+        contacts = argoalert.argo_web_api_to_contacts(
+            endpoint_topology_data, group_topology_data, api_use_notifications_flag, test_emails)
 
-    # merge site and service contacts
-    contacts = top_contacts + sub_contacts
+        
 
-    # Convert contacts to alerta mail rules
-    rules = argoalert.contacts_to_alerta(contacts, extra_emails, environment)
+         # Convert contacts to alerta mail rules
+        rules = argoalert.contacts_to_alerta(
+            contacts, extra_emails, environment)
 
-    # Save rules to alerta mailer rule file
-    argoalert.write_rules(rules, rule_file)
+        # Save rules to alerta mailer rule file
+        argoalert.write_rules(rules, rule_file)
+
+    # Handle old cases of gocdb and csv/json
+    else:
+
+        # Initialize authorization info object
+        auth_info = dict()
+
+        auth_method = parser.get("gocdb", "auth_method")
+        if auth_method == "cert":
+            auth_info["method"] = "cert"
+
+            auth_info["cert"] = parser.get("gocdb", "hostcert")
+            auth_info["key"] = parser.get("gocdb", "hostkey")
+        elif auth_method == "basic":
+            auth_info["method"] = "basic"
+            auth_info["user"] = parser.get("gocdb", "username")
+            auth_info["pass"] = parser.get("gocdb", "password")
+
+        gocdb_api = parser.get("gocdb", "api")
+        verify = parser.getboolean("gocdb", "verify")
+        ca_bundle = None
+        if verify:
+            ca_bundle = parser.get("gocdb", "cabundle")
+        use_notif_flag = parser.getboolean("gocdb", "use_notifications_flag")
+        rule_file = parser.get("alerta", "mail-rules")
+
+        top_req = parser.get("gocdb", "top_request")
+        sub_req = parser.get("gocdb", "sub_request")
+
+        extra_emails = []
+        # Check if configuration has extra emails defined
+        if parser.has_option("alerta", "extra-emails"):
+            extra_emails = parser.get("alerta", "extra-emails").split(",")
+
+        test_emails = None
+        if args.test_emails is not None:
+            test_emails = args.test_emails.split(',')
+
+        group_notify_flag = use_notif_flag
+        if args.group_notify_flag is not None:
+            if args.group_notify_flag.lower() in ('true', 'yes', 'y'):
+                group_notify_flag = True
+            else:
+                group_notify_flag = False
+
+        environment = None
+        if parser.has_option("alerta", "environment"):
+            environment = parser.get("alerta", "environment")
+
+        # Get site data from gocdb
+        top_url = gocdb_api + top_req
+        gocdb_site_xml = argoalert.get_gocdb(top_url, auth_info, ca_bundle)
+
+        # Convert top-level gocdb xml data to contacts object
+        top_contacts = argoalert.gocdb_to_contacts(
+            gocdb_site_xml, group_notify_flag, test_emails)
+
+        # Get sub level contact data from gocdb
+        sub_url = gocdb_api + sub_req
+        gocdb_service_xml = argoalert.get_gocdb(sub_url, auth_info, ca_bundle)
+
+        # Convert sub-level site gocdb xml data to contacts object
+        sub_contacts = argoalert.gocdb_to_contacts(
+            gocdb_service_xml, use_notif_flag, test_emails)
+
+        # merge site and service contacts
+        contacts = top_contacts + sub_contacts
+
+        # Convert contacts to alerta mail rules
+        rules = argoalert.contacts_to_alerta(
+            contacts, extra_emails, environment)
+
+        # Save rules to alerta mailer rule file
+        argoalert.write_rules(rules, rule_file)
 
 
 if __name__ == "__main__":

--- a/conf/argo-alert.conf.template
+++ b/conf/argo-alert.conf.template
@@ -1,9 +1,20 @@
 [feed]
-# Feed type for contacts simple / gocdb
-feed_type=gocdb
+# Feed type for contacts simple / gocdb / argo-web-api
+feed_type=argo-web-api
+
+[argo-web-api]
+# argo web api endpoint to connect to 
+endpoint=https://api.devel.example.foo
+# argo web api access token  
+access_key=s3cr3tt0ke3n
+# verify http requests
+verify=False 
+# select to honor notifications flag in rules or not 
+use_notifications_flag=True 
+
 
 [gocdb]
-# auth_method to be used when contacting gocdb api: basic-auth or cert
+# auth_method to be used when contacting gocdb api: basic-auth or cert or apikey
 auth_method=cert
 # username for basic auth
 username=

--- a/tests/files/api_contacts.json
+++ b/tests/files/api_contacts.json
@@ -1,0 +1,22 @@
+[
+    {
+      "name": "service1\\/host\\.sg_a\\.example\\.foo",
+      "emails": "hello1@example.foo;hello2@example.foo",
+      "type": "SERVICEGROUPS"
+    },
+    {
+      "name": "service2\\/host\\.sg_b\\.example\\.foo",
+      "emails": "hello3@example.foo;hello4@example.foo",
+      "type": "SERVICEGROUPS"
+    },
+    {
+      "name": "SG_A",
+      "emails": "hello5@example.foo",
+      "type": "SERVICEGROUPS"
+    },
+    {
+      "name": "SG_B",
+      "emails": "hello5@example.foo",
+      "type": "SERVICEGROUPS"
+    }
+  ]

--- a/tests/files/api_rules.json
+++ b/tests/files/api_rules.json
@@ -1,0 +1,56 @@
+[
+    {
+      "contacts": [
+        "hello1@example.foo",
+        "hello2@example.foo"
+      ],
+      "exclude": true,
+      "fields": [
+        {
+          "field": "resource",
+          "regex": "^service1\\/host\\.sg_a\\.example\\.foo($|\\/)"
+        }
+      ],
+      "name": "rule_service1\\/host\\.sg_a\\.example\\.foo"
+    },
+    {
+      "contacts": [
+        "hello3@example.foo",
+        "hello4@example.foo"
+      ],
+      "exclude": true,
+      "fields": [
+        {
+          "field": "resource",
+          "regex": "^service2\\/host\\.sg_b\\.example\\.foo($|\\/)"
+        }
+      ],
+      "name": "rule_service2\\/host\\.sg_b\\.example\\.foo"
+    },
+    {
+      "contacts": [
+        "hello5@example.foo"
+      ],
+      "exclude": true,
+      "fields": [
+        {
+          "field": "resource",
+          "regex": "^SG_A($|\\/)"
+        }
+      ],
+      "name": "rule_SG_A"
+    },
+    {
+      "contacts": [
+        "hello5@example.foo"
+      ],
+      "exclude": true,
+      "fields": [
+        {
+          "field": "resource",
+          "regex": "^SG_B($|\\/)"
+        }
+      ],
+      "name": "rule_SG_B"
+    }
+  ]

--- a/tests/files/argowebapi_endpoint_data.json
+++ b/tests/files/argowebapi_endpoint_data.json
@@ -1,0 +1,63 @@
+[
+    {
+        "date": "2022-06-30",
+        "group": "SG_A",
+        "type": "SERVICEGROUPS",
+        "service": "service1",
+        "hostname": "host.sg_a.example.foo",
+        "notifications": {
+            "contacts": [
+                "hello1@example.foo",
+                "hello2@example.foo"
+            ],
+            "enabled": true
+        },
+        "tags": {
+            "info_ID": "33",
+            "monitored": "1",
+            "production": "1",
+            "scope": "Scope1"
+        }
+    },
+    {
+        "date": "2022-06-30",
+        "group": "SG_B",
+        "type": "SERVICEGROUPS",
+        "service": "service2",
+        "hostname": "host.sg_b.example.foo",
+        "notifications": {
+            "contacts": [
+                "hello3@example.foo",
+                "hello4@example.foo"
+            ],
+            "enabled": true
+        },
+        "tags": {
+            "info_ID": "34",
+            "monitored": "1",
+            "production": "1",
+            "scope": "Scope1"
+        }
+    },
+    {
+        "date": "2022-06-30",
+        "group": "SG_C",
+        "type": "SERVICEGROUPS",
+        "service": "service3",
+        "hostname": "host.sg_c.example.foo",
+        "notifications": {
+            "contacts": [
+                "hello5@example.foo"
+               
+            ],
+            "enabled": false
+        },
+        "tags": {
+            "info_ID": "55",
+            "monitored": "1",
+            "production": "1",
+            "scope": "Scope1"
+        }
+    }
+   
+]

--- a/tests/files/argowebapi_group_data.json
+++ b/tests/files/argowebapi_group_data.json
@@ -1,0 +1,51 @@
+[
+    {
+        "date": "2022-30-06",
+        "group": "TOP",
+        "type": "PROJECT",
+        "subgroup": "SG_A",
+        "notifications": {
+            "contacts": [
+                "top_contact1@example.foo"
+            ],
+            "enabled": true
+        },
+        "tags": {
+            "monitored": "1",
+            "scope": "Top"
+        }
+    },
+    {
+        "date": "2022-30-06",
+        "group": "TOP",
+        "type": "PROJECT",
+        "subgroup": "SG_B",
+        "notifications": {
+            "contacts": [
+                "top_contact2@example.foo"
+            ],
+            "enabled": true
+        },
+        "tags": {
+            "monitored": "1",
+            "scope": "Top"
+        }
+    },
+    {
+        "date": "2022-30-06",
+        "group": "TOP",
+        "type": "PROJECT",
+        "subgroup": "SG_C",
+        "notifications": {
+            "contacts": [
+                "top_contact3@example.foo"
+            ],
+            "enabled": false
+        },
+        "tags": {
+            "monitored": "1",
+            "scope": "Top"
+        }
+    }
+   
+]

--- a/tests/files/sg_contacts_all.json
+++ b/tests/files/sg_contacts_all.json
@@ -2,21 +2,21 @@
   {
     "type": "SERVICE_GROUP",
     "name": "SG_A",
-    "email": "sg_a@email.foo,sg_x@email.foo   ; sg_y@email.com   "
+    "emails": "sg_a@email.foo,sg_x@email.foo   ; sg_y@email.com   "
   },
   {
     "type": "SERVICE_GROUP",
     "name": "SG_B",
-    "email": "sg_b@email.foo"
+    "emails": "sg_b@email.foo"
   },
   {
     "type": "SERVICE_GROUP",
     "name": "SG_C",
-    "email": "sg_c@email.foo;sg_w@email.foo"
+    "emails": "sg_c@email.foo;sg_w@email.foo"
   },
   {
     "type": "SERVICE_GROUP",
     "name": "SG_D",
-    "email": "sg_d@email.foo"
+    "emails": "sg_d@email.foo"
   }
 ]

--- a/tests/files/sg_contacts_notify.json
+++ b/tests/files/sg_contacts_notify.json
@@ -2,16 +2,16 @@
   {
     "type": "SERVICE_GROUP",
     "name": "SG_A",
-    "email": "sg_a@email.foo,sg_x@email.foo   ; sg_y@email.com   "
+    "emails": "sg_a@email.foo,sg_x@email.foo   ; sg_y@email.com   "
   },
   {
     "type": "SERVICE_GROUP",
     "name": "SG_C",
-    "email": "sg_c@email.foo;sg_w@email.foo"
+    "emails": "sg_c@email.foo;sg_w@email.foo"
   },
   {
     "type": "SERVICE_GROUP",
     "name": "SG_D",
-    "email": "sg_d@email.foo"
+    "emails": "sg_d@email.foo"
   }
 ]

--- a/tests/files/site_contacts_all.json
+++ b/tests/files/site_contacts_all.json
@@ -2,26 +2,26 @@
   {
     "type": "SITE",
     "name": "Site-A",
-    "email": "admin@site-a.email.foo"
+    "emails": "admin@site-a.email.foo"
   },
   {
     "type": "SITE",
     "name": "Site-B",
-    "email": "admin@site-b.email.foo"
+    "emails": "admin@site-b.email.foo"
   },
   {
     "type": "SITE",
     "name": "Site-C",
-    "email": "admin@site-c.email.foo"
+    "emails": "admin@site-c.email.foo"
   },
   {
     "type": "SITE",
     "name": "Site-D",
-    "email": "admin@site-d.email.foo"
+    "emails": "admin@site-d.email.foo"
   },
   {
     "type": "SITE",
     "name": "Site-F",
-    "email": "admin@site-f.email.foo"
+    "emails": "admin@site-f.email.foo"
   }
 ]

--- a/tests/files/site_contacts_notify.json
+++ b/tests/files/site_contacts_notify.json
@@ -2,21 +2,21 @@
   {
     "type": "SITE",
     "name": "Site-A",
-    "email": "admin@site-a.email.foo"
+    "emails": "admin@site-a.email.foo"
   },
   {
     "type": "SITE",
     "name": "Site-B",
-    "email": "admin@site-b.email.foo"
+    "emails": "admin@site-b.email.foo"
   },
   {
     "type": "SITE",
     "name": "Site-D",
-    "email": "admin@site-d.email.foo"
+    "emails": "admin@site-d.email.foo"
   },
   {
     "type": "SITE",
     "name": "Site-F",
-    "email": "admin@site-f.email.foo"
+    "emails": "admin@site-f.email.foo"
   }
 ]

--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -4,6 +4,8 @@ from argoalert import argoalert
 import os
 
 
+
+
 # establish path for the resource
 def get_resource_path(relative_path):
     return os.path.join(os.path.dirname(__file__), relative_path)
@@ -101,7 +103,6 @@ class TestArgoAlertMethods(unittest.TestCase):
 
                 use_notif_flag = True
                 contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, None)
-
                 self.assertEqual(contacts, exp_json)
 
             # Select all contacts
@@ -179,6 +180,25 @@ class TestArgoAlertMethods(unittest.TestCase):
                 contacts = argoalert.gocdb_to_contacts(xml_data, use_notif_flag, None)
 
                 self.assertEqual(contacts, exp_json)
+
+    # Test api contacts to alerta transformation
+    def test_api_contacts_to_alerta(self):
+
+        apifn = get_resource_path("./files/api_contacts.json")
+        rfn = get_resource_path("./files/api_rules.json")
+
+        with open(rfn, 'r') as rule_json:
+            rule_data = rule_json.read().replace('\n', '')
+            exp_json = json.loads(rule_data)
+
+            with open(apifn, 'r') as contact_json:
+                contact_data = contact_json.read().replace('\n', '')
+                contacts = json.loads(contact_data)
+                rules = argoalert.contacts_to_alerta(contacts, [])
+                rules_out = json.dumps(rules, sort_keys=True)
+                exp_out = json.dumps(exp_json, sort_keys=True)
+                self.assertEqual(rules_out, exp_out)
+
 
     # Test servicegroup contacts to alerta transformation
     def test_sg_contacts_to_alerta(self):
@@ -280,6 +300,29 @@ class TestArgoAlertMethods(unittest.TestCase):
                 rules = argoalert.contacts_to_alerta(contacts, extra_emails)
 
                 self.assertEqual(exp_json, rules)
+
+    # Test argowebapi contacts
+    def test_argo_web_api(self):
+        endpoint_data_fn = get_resource_path("./files/argowebapi_endpoint_data.json")
+        group_data_fn = get_resource_path("./files/argowebapi_group_data.json")
+        api_contacts_fn = get_resource_path("./files/api_contacts.json")
+
+        with open(endpoint_data_fn, 'r') as endpoint_txt:
+            endpoint_clean = endpoint_txt.read().replace('\n', '')
+            endpoint_data = json.loads(endpoint_clean)
+
+            with open(group_data_fn, 'r') as group_txt:
+                group_clean = group_txt.read().replace('\n', '')
+                group_data = json.loads(group_clean)
+
+                with open(api_contacts_fn, 'r') as api_contacts_txt:
+                    api_contacts_clean = api_contacts_txt.read().replace('\n', '')
+                    api_contacts_data = json.loads(api_contacts_clean)
+
+                    contacts = argoalert.argo_web_api_to_contacts(endpoint_data,group_data,True)
+                    print(contacts)
+                    self.assertEqual(contacts,api_contacts_data)
+
 
 
 


### PR DESCRIPTION
Retrieve contact information directly from argo-web-api

- [x] Implement get_argo_web_api data method to retrieve topology data for endpoints and groups (and associated contact information
- [x] Implement argo_web_api_to_contacts method to create a generic list to transform argo-web-api data to a generic list of items and associated contacts
- [x] update unit tests
