### PR TITLE
ARGO-4216 Generate endpoint notification rules based on group contacts

### DIFF
--- a/argoalert/argoalert.py
+++ b/argoalert/argoalert.py
@@ -354,13 +354,36 @@ def gocdb_to_contacts(gocdb_xml, use_notif_flag, test_emails):
     return contacts
 
 
+def gen_endpoint_contacts_from_groups(group_data, endpoint_data):
+    """Parse both endpoint and group topology data and refactor endpoint data using
+       notification information from groups
+
+    Args:
+        endpoint_data (obj): list of endpoint topology data
+        grou_data (string): list of group topology data
+
+    Returns:
+        obj: list containing endpoint topology data with notification detailes borrowed from groups
+    """
+    group_index = {}
+    gen_endpoints = []
+    for item in group_data:
+        group_index[item["subgroup"]] = item["notifications"]
+    for item in endpoint_data:
+        endpoint_group = item["group"]
+       
+        if endpoint_group in group_index:
+            item["notifications"] = group_index[endpoint_group]
+            gen_endpoints.append(item)
+    
+    return gen_endpoints
 
 def argo_web_api_to_contacts(endpoint_data, group_data, use_notif=False, test_emails=None):
     """Contact argo-web-api endpoint and retrieve contacts for topology endpoints and groups
 
     Args:
-        api_endpoint (string): endpoint for argo-web-api instance
-        access_key (string): argo-web-api access key
+        endpoint_data (obj): list of endpoint topology data
+        grou_data (string): list of group topology data
         verify (bool, optional): Set https verification on/off. Defaults to True.
         test_emails (string, optional): Set test emails for notifications. Defaults to None
 

--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -41,6 +41,11 @@ def main(args=None):
         if args.test_emails is not None:
             test_emails = args.test_emails.split(',')
 
+        gen_endpoint_contacts = False
+        # Check if configuration has endpoint contacts from groups
+        if parser.has_option("alerta", "endpoint-contacts-from-groups"):
+            gen_endpoint_contacts = parser.getboolean("alerta", "endpoint-contacts-from-groups")           
+
         # get endpoint topology
         endpoint_topology_data = argoalert.get_argo_web_api_data(
             api_endpoint, api_access_key, api_verify, "endpoints")
@@ -48,6 +53,10 @@ def main(args=None):
         # get group topology
         group_topology_data = argoalert.get_argo_web_api_data(
             api_endpoint, api_access_key, api_verify, "groups")
+        
+        # check if configuration dictates to generate endpoint contacts based on group contacts
+        if gen_endpoint_contacts:
+            endpoint_topology_data = argoalert.gen_endpoint_contacts_from_groups(group_topology_data, endpoint_topology_data)
 
         contacts = argoalert.argo_web_api_to_contacts(
             endpoint_topology_data, group_topology_data, api_use_notifications_flag, test_emails)

--- a/conf/argo-alert.conf.template
+++ b/conf/argo-alert.conf.template
@@ -65,6 +65,8 @@ alert-timeout = 3600
 # group type of the tenant's top level group used in alert generation and mail template
 group-type = Group
 report = Critical
+# generate endpoint notifications based on groups
+endpoint-contacts-from-groups = False
 
 [logging]
 # loggin level

--- a/tests/files/gen_endpoint_contacts.json
+++ b/tests/files/gen_endpoint_contacts.json
@@ -1,0 +1,59 @@
+[
+    {
+      "date": "2022-06-30",
+      "group": "SG_A",
+      "type": "SERVICEGROUPS",
+      "service": "service1",
+      "hostname": "host.sg_a.example.foo",
+      "notifications": {
+        "contacts": [
+          "top_contact1@example.foo"
+        ],
+        "enabled": true
+      },
+      "tags": {
+        "info_ID": "33",
+        "monitored": "1",
+        "production": "1",
+        "scope": "Scope1"
+      }
+    },
+    {
+      "date": "2022-06-30",
+      "group": "SG_B",
+      "type": "SERVICEGROUPS",
+      "service": "service2",
+      "hostname": "host.sg_b.example.foo",
+      "notifications": {
+        "contacts": [
+          "top_contact2@example.foo"
+        ],
+        "enabled": true
+      },
+      "tags": {
+        "info_ID": "34",
+        "monitored": "1",
+        "production": "1",
+        "scope": "Scope1"
+      }
+    },
+    {
+      "date": "2022-06-30",
+      "group": "SG_C",
+      "type": "SERVICEGROUPS",
+      "service": "service3",
+      "hostname": "host.sg_c.example.foo",
+      "notifications": {
+        "contacts": [
+          "top_contact3@example.foo"
+        ],
+        "enabled": false
+      },
+      "tags": {
+        "info_ID": "55",
+        "monitored": "1",
+        "production": "1",
+        "scope": "Scope1"
+      }
+    }
+  ]

--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -324,5 +324,24 @@ class TestArgoAlertMethods(unittest.TestCase):
                     self.assertEqual(contacts,api_contacts_data)
 
 
+    def test_gen_group_contacts(self):
+        endpoint_data_fn = get_resource_path("./files/argowebapi_endpoint_data.json")
+        group_data_fn = get_resource_path("./files/argowebapi_group_data.json")
+        gen_contacts_fn = get_resource_path("./files/gen_endpoint_contacts.json")
+
+        with open(endpoint_data_fn, 'r') as endpoint_txt:
+            endpoint_clean = endpoint_txt.read().replace('\n', '')
+            endpoint_data = json.loads(endpoint_clean)
+
+            with open(group_data_fn, 'r') as group_txt:
+                group_clean = group_txt.read().replace('\n', '')
+                group_data = json.loads(group_clean)
+
+                with open(gen_contacts_fn, 'r') as gen_contacts_txt:
+                    gen_contacts_clean = gen_contacts_txt.read().replace('\n', '')
+                    gen_contacts_data = json.loads(gen_contacts_clean)
+
+                    gen_contacts = argoalert.gen_endpoint_contacts_from_groups(group_data, endpoint_data)
+                    self.assertEqual(gen_contacts,gen_contacts_data)
 
 


### PR DESCRIPTION
## Goal
Give the ability to quickly generate endpoint notifications based on group contacts. For each group owner serveral endpoint notification rules are generated for included endpoints using that group owner contact information. 

## Implementation
- [x] Add `gen_endpoint_contacts_from_groups` method that refactors endpoint topology data using relevant notification information from group topology
- [x] Update configuration with parameter `endpoint-contacts-from-groups` which default to False to trigger this optional functionality
- [x] Add unit tests 