### PR TITLE
ARGO-4229 Add the ability to skip group contact generation. Fix handl…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
         stage ('Test Centos 7') {
             agent {
                 docker {
-                    image 'argo.registry:5000/epel-7-ams'
+                    image 'argo.registry:5000/python3'
                     args '-u jenkins:jenkins'
                 }
             }
@@ -19,7 +19,7 @@ pipeline {
                     cd ${WORKSPACE}/$PROJECT_DIR
                     pipenv install -r requirements.txt
                     pipenv run python setup.py install
-                    pipenv run coverage run --source=./argoalert -m py.test
+                    pipenv run coverage run --source=./argoalert -m pytest
                     pipenv run coverage xml
                     pipenv run py.test ./ --junitxml=./junit.xml
                 '''

--- a/argoalert/argoalert.py
+++ b/argoalert/argoalert.py
@@ -401,7 +401,8 @@ def argo_web_api_to_contacts(endpoint_data, group_data, use_notif=False, test_em
     for indx, endpoint in enumerate(endpoint_data):
         subgroup_types[endpoint["group"]]=endpoint["type"]
         if "notifications" in endpoint:
-            if get_notif_always or (endpoint["notifications"]["enabled"] == True):
+            # if notifications is empty
+            if get_notif_always or ("enabled" in endpoint["notifications"] and endpoint["notifications"]["enabled"] == True):
                 name = "{}\\/{}".format(endpoint["service"].replace(".","\\."),endpoint["hostname"].replace(".","\\."))
                 if not test_emails:
                     contact = ";".join(endpoint["notifications"]["contacts"])
@@ -412,7 +413,8 @@ def argo_web_api_to_contacts(endpoint_data, group_data, use_notif=False, test_em
     for indx, group in enumerate(group_data):
         if "notifications" not in group:
             continue
-        if get_notif_always or (group["notifications"]["enabled"] == True):
+        
+        if get_notif_always or ("enabled" in group["notifications"] and group["notifications"]["enabled"] == True):
             name = group["subgroup"]
             if name not in subgroup_types:
                 continue

--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -42,9 +42,15 @@ def main(args=None):
             test_emails = args.test_emails.split(',')
 
         gen_endpoint_contacts = False
+        skip_group_contacts = False
         # Check if configuration has endpoint contacts from groups
         if parser.has_option("alerta", "endpoint-contacts-from-groups"):
-            gen_endpoint_contacts = parser.getboolean("alerta", "endpoint-contacts-from-groups")           
+            gen_endpoint_contacts = parser.getboolean("alerta", "endpoint-contacts-from-groups")
+        
+        # Check if configuration has group contacts for generations
+        if parser.has_option("alerta", "skip-group-contacts"):
+            skip_group_contacts = parser.getboolean("alerta", "skip-group-contacts")     
+                   
 
         # get endpoint topology
         endpoint_topology_data = argoalert.get_argo_web_api_data(
@@ -57,6 +63,9 @@ def main(args=None):
         # check if configuration dictates to generate endpoint contacts based on group contacts
         if gen_endpoint_contacts:
             endpoint_topology_data = argoalert.gen_endpoint_contacts_from_groups(group_topology_data, endpoint_topology_data)
+
+        if skip_group_contacts:
+            group_topology_data = []
 
         contacts = argoalert.argo_web_api_to_contacts(
             endpoint_topology_data, group_topology_data, api_use_notifications_flag, test_emails)

--- a/conf/argo-alert.conf.template
+++ b/conf/argo-alert.conf.template
@@ -67,6 +67,8 @@ group-type = Group
 report = Critical
 # generate endpoint notifications based on groups
 endpoint-contacts-from-groups = False
+# don't generate group contacts
+skip-group-contacts = False
 
 [logging]
 # loggin level


### PR DESCRIPTION
…ing when notifications.enabled field is missing from json

- [x] Add the ability to skip group contact generation. This is useful in cases we need to generate endpoint contacts from groups and we don't want to send also group notifications
- [x] In some api tenants the "enabled" field is not always present in topology notification data. This must be handled properly.
