### PR TITLE
ARGO-4247 Handle endpoints belonging to multiple groups - filter by group type

### DIFF
--- a/bin/argo-alert-rulegen
+++ b/bin/argo-alert-rulegen
@@ -42,10 +42,13 @@ def main(args=None):
             test_emails = args.test_emails.split(',')
 
         gen_endpoint_contacts = False
+        gen_endpoint_contacts_group_filter = None
         skip_group_contacts = False
         # Check if configuration has endpoint contacts from groups
-        if parser.has_option("alerta", "endpoint-contacts-from-groups"):
-            gen_endpoint_contacts = parser.getboolean("alerta", "endpoint-contacts-from-groups")
+        if parser.has_option("alerta", "gen-endpoint-contacts-from-groups"):
+            gen_endpoint_contacts = parser.getboolean("alerta", "gen-endpoint-contacts-from-groups")
+        if parser.has_option("alerta", "gen-endpoint-contacts-group-filter"):
+            gen_endpoint_contacts_group_filter = parser.get("alerta", "gen-endpoint-contacts-group-filter")
         
         # Check if configuration has group contacts for generations
         if parser.has_option("alerta", "skip-group-contacts"):
@@ -62,7 +65,9 @@ def main(args=None):
         
         # check if configuration dictates to generate endpoint contacts based on group contacts
         if gen_endpoint_contacts:
-            endpoint_topology_data = argoalert.gen_endpoint_contacts_from_groups(group_topology_data, endpoint_topology_data)
+            endpoint_topology_data = argoalert.gen_endpoint_contacts_from_groups(
+                group_topology_data, endpoint_topology_data, gen_endpoint_contacts_group_filter
+            )
 
         if skip_group_contacts:
             group_topology_data = []

--- a/conf/argo-alert.conf.template
+++ b/conf/argo-alert.conf.template
@@ -66,7 +66,9 @@ alert-timeout = 3600
 group-type = Group
 report = Critical
 # generate endpoint notifications based on groups
-endpoint-contacts-from-groups = False
+gen-endpoint-contacts-from-groups = False
+# Optional: when generating endpoint contacts from groups filter by group type
+# gen-endpoint-contacts-group-filter = SITES 
 # don't generate group contacts
 skip-group-contacts = False
 

--- a/tests/files/api_contacts.json
+++ b/tests/files/api_contacts.json
@@ -1,22 +1,27 @@
 [
-    {
+  {
       "name": "service1\\/host\\.sg_a\\.example\\.foo",
-      "emails": "hello1@example.foo;hello2@example.foo",
-      "type": "SERVICEGROUPS"
-    },
-    {
+      "emails": "hello1@example.foo;hello2@example.foo;hello8@example.foo",
+      "type": "endpoint"
+  },
+  {
       "name": "service2\\/host\\.sg_b\\.example\\.foo",
       "emails": "hello3@example.foo;hello4@example.foo",
-      "type": "SERVICEGROUPS"
-    },
-    {
+      "type": "endpoint"
+  },
+  {
       "name": "SG_A",
-      "emails": "hello5@example.foo",
+      "emails": "top_contact1@example.foo",
       "type": "SERVICEGROUPS"
-    },
-    {
+  },
+  {
       "name": "SG_B",
-      "emails": "hello5@example.foo",
+      "emails": "top_contact2@example.foo",
       "type": "SERVICEGROUPS"
-    }
-  ]
+  },
+  {
+      "name": "SG_X",
+      "emails": "top_contact8@example.foo",
+      "type": "SITES"
+  }
+]

--- a/tests/files/api_rules.json
+++ b/tests/files/api_rules.json
@@ -1,56 +1,70 @@
 [
-    {
-      "contacts": [
-        "hello1@example.foo",
-        "hello2@example.foo"
-      ],
-      "exclude": true,
+  {
+      "name": "rule_service1\\/host\\.sg_a\\.example\\.foo",
       "fields": [
-        {
-          "field": "resource",
-          "regex": "^service1\\/host\\.sg_a\\.example\\.foo($|\\/)"
-        }
+          {
+              "field": "resource",
+              "regex": "^service1\\/host\\.sg_a\\.example\\.foo($|\\/)"
+          }
       ],
-      "name": "rule_service1\\/host\\.sg_a\\.example\\.foo"
-    },
-    {
       "contacts": [
-        "hello3@example.foo",
-        "hello4@example.foo"
+          "hello1@example.foo",
+          "hello2@example.foo",
+          "hello8@example.foo"
       ],
-      "exclude": true,
+      "exclude": true
+  },
+  {
+      "name": "rule_service2\\/host\\.sg_b\\.example\\.foo",
       "fields": [
-        {
-          "field": "resource",
-          "regex": "^service2\\/host\\.sg_b\\.example\\.foo($|\\/)"
-        }
+          {
+              "field": "resource",
+              "regex": "^service2\\/host\\.sg_b\\.example\\.foo($|\\/)"
+          }
       ],
-      "name": "rule_service2\\/host\\.sg_b\\.example\\.foo"
-    },
-    {
       "contacts": [
-        "hello5@example.foo"
+          "hello3@example.foo",
+          "hello4@example.foo"
       ],
-      "exclude": true,
+      "exclude": true
+  },
+  {
+      "name": "rule_SG_A",
       "fields": [
-        {
-          "field": "resource",
-          "regex": "^SG_A($|\\/)"
-        }
+          {
+              "field": "resource",
+              "regex": "^SG_A($|\\/)"
+          }
       ],
-      "name": "rule_SG_A"
-    },
-    {
       "contacts": [
-        "hello5@example.foo"
+          "top_contact1@example.foo"
       ],
-      "exclude": true,
+      "exclude": true
+  },
+  {
+      "name": "rule_SG_B",
       "fields": [
-        {
-          "field": "resource",
-          "regex": "^SG_B($|\\/)"
-        }
+          {
+              "field": "resource",
+              "regex": "^SG_B($|\\/)"
+          }
       ],
-      "name": "rule_SG_B"
-    }
-  ]
+      "contacts": [
+          "top_contact2@example.foo"
+      ],
+      "exclude": true
+  },
+  {
+      "name": "rule_SG_X",
+      "fields": [
+          {
+              "field": "resource",
+              "regex": "^SG_X($|\\/)"
+          }
+      ],
+      "contacts": [
+          "top_contact8@example.foo"
+      ],
+      "exclude": true
+  }
+]

--- a/tests/files/argowebapi_endpoint_data.json
+++ b/tests/files/argowebapi_endpoint_data.json
@@ -58,6 +58,26 @@
             "production": "1",
             "scope": "Scope1"
         }
+    },
+    {
+        "date": "2022-06-30",
+        "group": "SG_X",
+        "type": "SITES",
+        "service": "service1",
+        "hostname": "host.sg_a.example.foo",
+        "notifications": {
+            "contacts": [
+                "hello8@example.foo"
+               
+            ],
+            "enabled": true
+        },
+        "tags": {
+            "info_ID": "55",
+            "monitored": "1",
+            "production": "1",
+            "scope": "Scope1"
+        }
     }
    
 ]

--- a/tests/files/argowebapi_group_data.json
+++ b/tests/files/argowebapi_group_data.json
@@ -46,6 +46,22 @@
             "monitored": "1",
             "scope": "Top"
         }
+    },
+    {
+        "date": "2022-30-06",
+        "group": "TOP",
+        "type": "PROJECT",
+        "subgroup": "SG_X",
+        "notifications": {
+            "contacts": [
+                "top_contact8@example.foo"
+            ],
+            "enabled": true
+        },
+        "tags": {
+            "monitored": "1",
+            "scope": "Top"
+        }
     }
    
 ]

--- a/tests/files/gen_endpoint_contacts_filter.json
+++ b/tests/files/gen_endpoint_contacts_filter.json
@@ -55,24 +55,5 @@
           "production": "1",
           "scope": "Scope1"
       }
-  },
-  {
-      "date": "2022-06-30",
-      "group": "SG_X",
-      "type": "SITES",
-      "service": "service1",
-      "hostname": "host.sg_a.example.foo",
-      "notifications": {
-          "contacts": [
-              "top_contact8@example.foo"
-          ],
-          "enabled": true
-      },
-      "tags": {
-          "info_ID": "55",
-          "monitored": "1",
-          "production": "1",
-          "scope": "Scope1"
-      }
   }
 ]

--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -135,9 +135,6 @@ class TestArgoAlertMethods(unittest.TestCase):
                 use_notif_flag = True
                 contacts = argoalert.json_feed_to_contacts(json.dumps(json_og_data), use_notif_flag, None, "SERVICE_GROUP")
 
-                print(contacts)
-                print(exp_json)
-
                 self.assertEqual(contacts, exp_json)
 
             # Select all contacts
@@ -197,6 +194,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                 rules = argoalert.contacts_to_alerta(contacts, [])
                 rules_out = json.dumps(rules, sort_keys=True)
                 exp_out = json.dumps(exp_json, sort_keys=True)
+                print(json.dumps(rules,indent=4))
                 self.assertEqual(rules_out, exp_out)
 
 
@@ -216,11 +214,9 @@ class TestArgoAlertMethods(unittest.TestCase):
                 rules = argoalert.contacts_to_alerta(contacts, [])
                 rules_out = json.dumps(rules, sort_keys=True)
                 exp_out = json.dumps(exp_json, sort_keys=True)
-
                 self.assertEqual(rules_out, exp_out)
                
-
-     # Test site contacts to alerta transformation
+    # Test site contacts to alerta transformation
     def test_site_contacts_to_alerta(self):
         cfn = get_resource_path("./files/site_contacts_notify.json")
         rfn = get_resource_path("./files/site_rules.json")
@@ -320,7 +316,8 @@ class TestArgoAlertMethods(unittest.TestCase):
                     api_contacts_data = json.loads(api_contacts_clean)
 
                     contacts = argoalert.argo_web_api_to_contacts(endpoint_data,group_data,True)
-                    print(contacts)
+                    print(json.dumps(contacts, indent=4))
+                    print(json.dumps(api_contacts_data, indent=4))
                     self.assertEqual(contacts,api_contacts_data)
 
 
@@ -342,6 +339,28 @@ class TestArgoAlertMethods(unittest.TestCase):
                     gen_contacts_data = json.loads(gen_contacts_clean)
 
                     gen_contacts = argoalert.gen_endpoint_contacts_from_groups(group_data, endpoint_data)
+                    self.assertEqual(gen_contacts,gen_contacts_data)
+
+    def test_gen_group_contacts_filter(self):
+        endpoint_data_fn = get_resource_path("./files/argowebapi_endpoint_data.json")
+        group_data_fn = get_resource_path("./files/argowebapi_group_data.json")
+        gen_contacts_fn = get_resource_path("./files/gen_endpoint_contacts_filter.json")
+
+        with open(endpoint_data_fn, 'r') as endpoint_txt:
+            endpoint_clean = endpoint_txt.read().replace('\n', '')
+            endpoint_data = json.loads(endpoint_clean)
+
+            with open(group_data_fn, 'r') as group_txt:
+                group_clean = group_txt.read().replace('\n', '')
+                group_data = json.loads(group_clean)
+
+                with open(gen_contacts_fn, 'r') as gen_contacts_txt:
+                    gen_contacts_clean = gen_contacts_txt.read().replace('\n', '')
+                    gen_contacts_data = json.loads(gen_contacts_clean)
+
+                    gen_contacts = argoalert.gen_endpoint_contacts_from_groups(group_data, endpoint_data, "SERVICEGROUPS")
+                    print(json.dumps(gen_contacts, indent=4))
+                    print(json.dumps(gen_contacts_data, indent=4))
                     self.assertEqual(gen_contacts,gen_contacts_data)
 
 


### PR DESCRIPTION

- Handle endpoints belonging to multiple groups
- Optionally filter groups by desired group name (e.g. SITES)
- Handle cases where a notification object is present in the api topology but doesn't have a `contacts` field