### PR TITLE
ARGO-5020 - Add endpoint-type and ui-path-group parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ extra-emails=alert01@mail.example.foo,alert02@mail.example.foo
 aleart-timeout = 3600
 # group type of the tenant's top level group used in alert generation and mail template
 group-type = Group
+# endpoint type could be set to the default: endpoint or to another type (for example: service instance)
+endpoint-type = endpoint
+# ui-path-group is used in argo ui's result to define the correct type of group in results path
+ui-path-group = SITES
 # report name used in argo-web-ui url construction
 report = Critical
 

--- a/bin/argo-alert-publisher
+++ b/bin/argo-alert-publisher
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/alerta/bin/python
 
 from argparse import ArgumentParser
 from configparser import ConfigParser
@@ -19,7 +19,7 @@ def main(args=None):
     environment = parser.get("alerta", "environment")
     alerta_token = parser.get("alerta", "token")
     log_level = parser.get("logging", "level")
-    logging.basicConfig(level=log_level)
+    logging.basicConfig(level=log_level,format='%(asctime)s - %(levelname)s - %(message)s')
 
     # default alert timeout value
     alert_timeout = 3600
@@ -30,6 +30,15 @@ def main(args=None):
     if parser.has_option("alerta", "group-type"):
         group_type = parser.get("alerta", "group-type")
 
+    ui_path_group = "SITES"
+    if parser.has_option("alerta", "ui-path-group"):
+        ui_path_group = parser.get("alerta", "ui-path-group")
+
+
+    endpoint_type = "Endpoint"
+    if parser.has_option("alerta", "endpoint-type"):
+        endpoint_type = parser.get("alerta", "endpoint-type")
+
     report = "Critical"
     if parser.has_option("alerta", "report"):
         report = parser.get("alerta", "report")
@@ -39,8 +48,10 @@ def main(args=None):
         ui_endpoint = parser.get("alerta", "ui_endpoint")
 
     # create alert options dictionary
-    options = {"timeout": alert_timeout, "group_type": group_type,
-               "report": report, "ui_endpoint": ui_endpoint}
+    options = {"timeout": alert_timeout, "group_type": group_type, "endpoint_type": endpoint_type,
+            "report": report, "ui_endpoint": ui_endpoint, "ui_path_group":ui_path_group }
+
+
 
     argoalert.start_listening(environment, kafka_endpoint,
                               kafka_topic, alerta_endpoint, alerta_token, options)

--- a/conf/argo-alert.conf.template
+++ b/conf/argo-alert.conf.template
@@ -64,13 +64,17 @@ extra-emails=alert01@mail.example.foo,alert02@mail.example.foo
 alert-timeout = 3600
 # group type of the tenant's top level group used in alert generation and mail template
 group-type = Group
+endpoint-type = endpoint
 report = Critical
+ui-path-group = SITES
 # generate endpoint notifications based on groups
 gen-endpoint-contacts-from-groups = False
 # Optional: when generating endpoint contacts from groups filter by group type
 # gen-endpoint-contacts-group-filter = SITES 
 # don't generate group contacts
 skip-group-contacts = False
+
+
 
 [logging]
 # loggin level

--- a/tests/test_argoalert.py
+++ b/tests/test_argoalert.py
@@ -27,7 +27,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                   '"severity": "ok", "text": "[ DEVEL ] - Project SITEA is OK", "timeout": 20}'
 
         argo_json = json.loads(argo_str)
-        alerta_json = argoalert.transform(argo_json, "devel", "Project", 20,"ui.argo.foo", "Critical")
+        alerta_json = argoalert.transform(argo_json, "devel", "Project", 20,"ui.argo.foo", "Critical", "Service", "PROJECTS")
         alerta_str = json.dumps(alerta_json, sort_keys=True)
 
 
@@ -46,7 +46,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                    '"severity": "ok", "text": "[ DEVEL ] - Service httpd is OK", "timeout": 32}'
 
         argo_json = json.loads(argo_str)
-        alerta_json = argoalert.transform(argo_json, "devel", "", 32, "ui.argo.foo", "Critical")
+        alerta_json = argoalert.transform(argo_json, "devel", "", 32, "ui.argo.foo", "Critical","","")
         alerta_str = json.dumps(alerta_json, sort_keys=True)
 
         self.assertEqual(alerta_str, exp_str)
@@ -61,12 +61,13 @@ class TestArgoAlertMethods(unittest.TestCase):
                   '"_metric_names": "", "_metric_statuses": "", "_mon_message": "", "_mon_summary": "", ' \
                   '"_repeat": "false", "_service": "httpd", "_status_egroup": "", "_status_endpoint": "", "_status_metric": "", "_status_service": "", "_ts_monitored": "2018-04-24T13:35:33Z", "_ts_processed": ""}, "environment": ' \
                   '"devel", "event": "endpoint_status", "resource": "httpd/webserver01", "service": [' \
-                  '"endpoint"], "severity": "ok", "text": "[ DEVEL ] - Endpoint webserver01/httpd is OK", "timeout": ' \
+                  '"endpoint"], "severity": "ok", "text": "[ DEVEL ] - Service instance webserver01 (httpd) is OK", "timeout": ' \
                   '122}'
 
         argo_json = json.loads(argo_str)
-        alerta_json = argoalert.transform(argo_json, "devel", "Site", 122,"ui.argo.foo","Critical")
+        alerta_json = argoalert.transform(argo_json, "devel", "Site", 122,"ui.argo.foo","Critical","Service instance","SITES")
         alerta_str = json.dumps(alerta_json, sort_keys=True)
+        print(alerta_str)
 
         self.assertEqual(alerta_str, exp_str)
 
@@ -82,7 +83,7 @@ class TestArgoAlertMethods(unittest.TestCase):
                   '"timeout": 42}'
 
         argo_json = json.loads(argo_str)
-        alerta_json = argoalert.transform(argo_json, "devel", "", 42,"ui.argo.foo","Critical")
+        alerta_json = argoalert.transform(argo_json, "devel", "", 42,"ui.argo.foo","Critical", "", "")
         alerta_str = json.dumps(alerta_json, sort_keys=True)
 
         self.assertEqual(alerta_str, exp_str)


### PR DESCRIPTION
### Goal

Give the ability to be able to define an alias for "endpoint" in notification alerts/emails. For example a user can define the wording to be "service instance" or something else. For that we introduce a new configuration parameter named `endpoint-type`. 

Also if a user chooses to use a different wording for the group of endpoints (e.g. `Service` instead of `Sites` which might be defined as Sites in the report) we need to be able to generate the correct `more details...` url in the notification emails. Thus we introduce a new parameter which is called `ui-path-group` 

### Implementation
- [x] Update configuration templates
- [x] Parse the new parameters
- [x] Use the new parameters in argo-alert
- [x] Use the new parameters in argo-alert-publisher